### PR TITLE
feat: mTLS certificate management (cloud-only)

### DIFF
--- a/prisma/migrations/20260222194617_add_client_certificate/migration.sql
+++ b/prisma/migrations/20260222194617_add_client_certificate/migration.sql
@@ -1,0 +1,68 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `guardEncryptedPayload` on the `HelpRequest` table. All the data in the column will be lost.
+
+*/
+-- CreateTable
+CREATE TABLE "ClientCertificate" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "fingerprint" TEXT NOT NULL,
+    "serialNumber" TEXT NOT NULL,
+    "notBefore" DATETIME NOT NULL,
+    "notAfter" DATETIME NOT NULL,
+    "revoked" BOOLEAN NOT NULL DEFAULT false,
+    "revokedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ClientCertificate_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_HelpRequest" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "refCode" TEXT,
+    "apiKeyId" TEXT NOT NULL,
+    "expertId" TEXT NOT NULL,
+    "messages" TEXT,
+    "question" TEXT,
+    "response" TEXT,
+    "consumerPublicKey" TEXT,
+    "serverPublicKey" TEXT,
+    "serverPrivateKey" TEXT,
+    "respondedAt" DATETIME,
+    "consumerSignPubKey" TEXT,
+    "consumerEncryptPubKey" TEXT,
+    "providerSignPubKey" TEXT,
+    "providerEncryptPubKey" TEXT,
+    "contentFlags" TEXT,
+    "guardVerified" BOOLEAN NOT NULL DEFAULT false,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "expiresAt" DATETIME NOT NULL,
+    "closedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "HelpRequest_apiKeyId_fkey" FOREIGN KEY ("apiKeyId") REFERENCES "ApiKey" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "HelpRequest_expertId_fkey" FOREIGN KEY ("expertId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_HelpRequest" ("apiKeyId", "closedAt", "consumerEncryptPubKey", "consumerPublicKey", "consumerSignPubKey", "contentFlags", "createdAt", "expertId", "expiresAt", "id", "messages", "providerEncryptPubKey", "providerSignPubKey", "question", "refCode", "respondedAt", "response", "serverPrivateKey", "serverPublicKey", "status", "updatedAt") SELECT "apiKeyId", "closedAt", "consumerEncryptPubKey", "consumerPublicKey", "consumerSignPubKey", "contentFlags", "createdAt", "expertId", "expiresAt", "id", "messages", "providerEncryptPubKey", "providerSignPubKey", "question", "refCode", "respondedAt", "response", "serverPrivateKey", "serverPublicKey", "status", "updatedAt" FROM "HelpRequest";
+DROP TABLE "HelpRequest";
+ALTER TABLE "new_HelpRequest" RENAME TO "HelpRequest";
+CREATE UNIQUE INDEX "HelpRequest_refCode_key" ON "HelpRequest"("refCode");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ClientCertificate_fingerprint_key" ON "ClientCertificate"("fingerprint");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ClientCertificate_serialNumber_key" ON "ClientCertificate"("serialNumber");
+
+-- CreateIndex
+CREATE INDEX "ClientCertificate_userId_idx" ON "ClientCertificate"("userId");
+
+-- CreateIndex
+CREATE INDEX "ClientCertificate_fingerprint_idx" ON "ClientCertificate"("fingerprint");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   requests           HelpRequest[] @relation("ExpertRequests")
   accounts           Account[]
   sessions           Session[]
+  certificates       ClientCertificate[]
   createdAt          DateTime  @default(now())
   updatedAt          DateTime  @updatedAt
 }
@@ -143,4 +144,21 @@ model Message {
   
   @@index([requestId])
   @@index([messageId])
+}
+
+model ClientCertificate {
+  id           String    @id @default(cuid())
+  userId       String
+  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  name         String
+  fingerprint  String    @unique
+  serialNumber String    @unique
+  notBefore    DateTime
+  notAfter     DateTime
+  revoked      Boolean   @default(false)
+  revokedAt    DateTime?
+  createdAt    DateTime  @default(now())
+
+  @@index([userId])
+  @@index([fingerprint])
 }

--- a/src/app/api/v1/certificates/[id]/route.ts
+++ b/src/app/api/v1/certificates/[id]/route.ts
@@ -1,0 +1,32 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isCloud } from "@/lib/edition";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!isCloud()) {
+    return NextResponse.json({ error: "mTLS certificates are a cloud-only feature" }, { status: 403 });
+  }
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+  const { id } = await params;
+  const cert = await prisma.clientCertificate.findFirst({ where: { id, userId: user.id } });
+  if (!cert) {
+    return NextResponse.json({ error: "Certificate not found" }, { status: 404 });
+  }
+  if (cert.revoked) {
+    return NextResponse.json({ error: "Certificate is already revoked" }, { status: 400 });
+  }
+  const updated = await prisma.clientCertificate.update({
+    where: { id },
+    data: { revoked: true, revokedAt: new Date() },
+  });
+  return NextResponse.json({ id: updated.id, revoked: updated.revoked, revokedAt: updated.revokedAt });
+}

--- a/src/app/api/v1/certificates/route.ts
+++ b/src/app/api/v1/certificates/route.ts
@@ -1,0 +1,54 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { isCloud } from "@/lib/edition";
+import { generateClientCertificate } from "@/lib/mtls.cloud";
+import { certificateCreateSchema, validateBody } from "@/lib/validations";
+
+export async function POST(request: Request) {
+  if (!isCloud()) {
+    return NextResponse.json({ error: "mTLS certificates are a cloud-only feature" }, { status: 403 });
+  }
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+  const raw = await request.json();
+  const parsed = validateBody(certificateCreateSchema, raw);
+  if (!parsed.success) return parsed.response;
+  const { name, validityDays } = parsed.data;
+  const generated = generateClientCertificate(`${name} - ${user.email}`, validityDays);
+  const record = await prisma.clientCertificate.create({
+    data: {
+      userId: user.id, name,
+      fingerprint: generated.fingerprint, serialNumber: generated.serialNumber,
+      notBefore: generated.notBefore, notAfter: generated.notAfter,
+    },
+  });
+  return NextResponse.json({
+    id: record.id, name: record.name, fingerprint: record.fingerprint,
+    serialNumber: record.serialNumber, notBefore: record.notBefore, notAfter: record.notAfter,
+    certificate: generated.certificate, privateKey: generated.privateKey,
+  }, { status: 201 });
+}
+
+export async function GET() {
+  if (!isCloud()) {
+    return NextResponse.json({ error: "mTLS certificates are a cloud-only feature" }, { status: 403 });
+  }
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+  const certificates = await prisma.clientCertificate.findMany({
+    where: { userId: user.id },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true, name: true, fingerprint: true, serialNumber: true,
+      notBefore: true, notAfter: true, revoked: true, revokedAt: true, createdAt: true,
+    },
+  });
+  return NextResponse.json({ certificates });
+}

--- a/src/app/dashboard/certificates/page.tsx
+++ b/src/app/dashboard/certificates/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Certificate {
+  id: string;
+  name: string;
+  fingerprint: string;
+  serialNumber: string;
+  notBefore: string;
+  notAfter: string;
+  revoked: boolean;
+  revokedAt: string | null;
+  createdAt: string;
+}
+
+interface GeneratedCert {
+  id: string;
+  name: string;
+  fingerprint: string;
+  certificate: string;
+  privateKey: string;
+}
+
+export default function CertificatesPage() {
+  const [certs, setCerts] = useState<Certificate[]>([]);
+  const [name, setName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [generated, setGenerated] = useState<GeneratedCert | null>(null);
+  const [error, setError] = useState("");
+
+  const fetchCerts = useCallback(async () => {
+    try {
+      const res = await fetch("/api/v1/certificates");
+      if (res.ok) {
+        const data = await res.json();
+        setCerts(data.certificates || []);
+      }
+    } catch { /* ignore */ }
+  }, []);
+
+  useEffect(() => { fetchCerts(); }, [fetchCerts]);
+
+  const create = async () => {
+    if (!name.trim()) return;
+    setCreating(true);
+    setError("");
+    try {
+      const res = await fetch("/api/v1/certificates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim() }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to create certificate");
+        return;
+      }
+      const data = await res.json();
+      setGenerated(data);
+      setName("");
+      fetchCerts();
+    } catch { setError("Network error"); } finally { setCreating(false); }
+  };
+
+  const revoke = async (id: string) => {
+    if (!confirm("Revoke this certificate? This cannot be undone.")) return;
+    try {
+      const res = await fetch(`/api/v1/certificates/${id}`, { method: "DELETE" });
+      if (res.ok) fetchCerts();
+    } catch { /* ignore */ }
+  };
+
+  const download = (filename: string, content: string) => {
+    const blob = new Blob([content], { type: "application/x-pem-file" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const isExpired = (notAfter: string) => new Date(notAfter) < new Date();
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-black mb-1">mTLS Certificates</h1>
+      <p className="text-sm text-[#666] mb-6">
+        Manage client certificates for mutual TLS authentication. Cloud-only feature.
+      </p>
+
+      <div className="rounded-lg border border-[#eaeaea] bg-white p-5 mb-6">
+        <h2 className="text-sm font-semibold text-black mb-3">Generate New Certificate</h2>
+        <div className="flex gap-3">
+          <input
+            type="text"
+            placeholder="Certificate name (e.g. Production API)"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="flex-1 rounded-md border border-[#eaeaea] px-3 py-2 text-sm focus:border-black focus:outline-none"
+            onKeyDown={(e) => e.key === "Enter" && create()}
+          />
+          <button
+            onClick={create}
+            disabled={creating || !name.trim()}
+            className="rounded-md bg-black px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#333] disabled:opacity-50"
+          >
+            {creating ? "Generating..." : "Generate"}
+          </button>
+        </div>
+        {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+      </div>
+
+      {generated && (
+        <div className="rounded-lg border border-green-200 bg-green-50 p-5 mb-6">
+          <h3 className="text-sm font-semibold text-green-900 mb-2">
+            Certificate Generated: {generated.name}
+          </h3>
+          <p className="text-xs text-green-700 mb-1">
+            Fingerprint: <code className="font-mono">{generated.fingerprint}</code>
+          </p>
+          <p className="text-xs text-green-700 mb-3">
+            Download both files now — the private key will not be shown again.
+          </p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => download(`${generated.name}.crt`, generated.certificate)}
+              className="rounded-md border border-green-300 bg-white px-3 py-1.5 text-xs font-medium text-green-800 hover:bg-green-100"
+            >
+              Download Certificate (.crt)
+            </button>
+            <button
+              onClick={() => download(`${generated.name}.key`, generated.privateKey)}
+              className="rounded-md border border-green-300 bg-white px-3 py-1.5 text-xs font-medium text-green-800 hover:bg-green-100"
+            >
+              Download Private Key (.key)
+            </button>
+            <button onClick={() => setGenerated(null)} className="ml-auto text-xs text-green-600 hover:text-green-800">
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="rounded-lg border border-[#eaeaea] bg-white">
+        <div className="border-b border-[#eaeaea] px-5 py-3">
+          <h2 className="text-sm font-semibold text-black">Your Certificates</h2>
+        </div>
+        {certs.length === 0 ? (
+          <div className="px-5 py-8 text-center text-sm text-[#999]">No certificates yet. Generate one above.</div>
+        ) : (
+          <div className="divide-y divide-[#eaeaea]">
+            {certs.map((cert) => (
+              <div key={cert.id} className="flex items-center justify-between px-5 py-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-black truncate">{cert.name}</span>
+                    {cert.revoked && (
+                      <span className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700">REVOKED</span>
+                    )}
+                    {!cert.revoked && isExpired(cert.notAfter) && (
+                      <span className="rounded bg-yellow-100 px-1.5 py-0.5 text-[10px] font-medium text-yellow-700">EXPIRED</span>
+                    )}
+                    {!cert.revoked && !isExpired(cert.notAfter) && (
+                      <span className="rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-medium text-green-700">ACTIVE</span>
+                    )}
+                  </div>
+                  <p className="mt-0.5 text-xs text-[#999] font-mono truncate">{cert.fingerprint}</p>
+                  <p className="text-xs text-[#999]">Expires {new Date(cert.notAfter).toLocaleDateString()}</p>
+                </div>
+                {!cert.revoked && (
+                  <button
+                    onClick={() => revoke(cert.id)}
+                    className="ml-4 rounded-md border border-red-200 px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50"
+                  >
+                    Revoke
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/top-nav.tsx
+++ b/src/components/dashboard/top-nav.tsx
@@ -9,6 +9,8 @@ const navItems = [
   { label: "Providers", href: "/dashboard/providers" },
   { label: "Clients", href: "/dashboard/clients" },
   { label: "Requests", href: "/dashboard/requests" },
+  { label: "Certificates", href: "/dashboard/certificates" },
+  { label: "Analytics", href: "/dashboard/analytics" },
   { label: "Settings", href: "/dashboard/settings" },
 ];
 

--- a/src/lib/mtls.cloud.ts
+++ b/src/lib/mtls.cloud.ts
@@ -1,0 +1,64 @@
+/**
+ * mTLS certificate management — cloud-only feature.
+ * Licensed under LICENSE_CLOUD.md — requires HeySummon Cloud License.
+ */
+
+import forge from "node-forge";
+import crypto from "crypto";
+
+const CA_COMMON_NAME = "HeySummon Cloud CA";
+const CERT_VALIDITY_DAYS = 365;
+
+interface GeneratedCertificate {
+  certificate: string;
+  privateKey: string;
+  fingerprint: string;
+  serialNumber: string;
+  notBefore: Date;
+  notAfter: Date;
+}
+
+export function generateClientCertificate(
+  commonName: string,
+  validityDays: number = CERT_VALIDITY_DAYS
+): GeneratedCertificate {
+  const keys = forge.pki.rsa.generateKeyPair(2048);
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  const serial = crypto.randomBytes(16).toString("hex");
+  cert.serialNumber = serial;
+  const now = new Date();
+  const notAfter = new Date(now.getTime() + validityDays * 24 * 60 * 60 * 1000);
+  cert.validity.notBefore = now;
+  cert.validity.notAfter = notAfter;
+  const attrs = [
+    { name: "commonName", value: commonName },
+    { name: "organizationName", value: "HeySummon Cloud" },
+  ];
+  cert.setSubject(attrs);
+  cert.setIssuer([
+    { name: "commonName", value: CA_COMMON_NAME },
+    { name: "organizationName", value: "HeySummon Cloud" },
+  ]);
+  cert.setExtensions([
+    { name: "basicConstraints", cA: false },
+    { name: "keyUsage", digitalSignature: true, keyEncipherment: true },
+    { name: "extKeyUsage", clientAuth: true },
+  ]);
+  cert.sign(keys.privateKey, forge.md.sha256.create());
+  const certPem = forge.pki.certificateToPem(cert);
+  const keyPem = forge.pki.privateKeyToPem(keys.privateKey);
+  const fingerprint = computeFingerprint(certPem);
+  return { certificate: certPem, privateKey: keyPem, fingerprint, serialNumber: serial, notBefore: now, notAfter };
+}
+
+export function computeFingerprint(certPem: string): string {
+  const cert = forge.pki.certificateFromPem(certPem);
+  const der = forge.asn1.toDer(forge.pki.certificateToAsn1(cert)).getBytes();
+  return crypto.createHash("sha256").update(Buffer.from(der, "binary")).digest("hex");
+}
+
+export function verifyFingerprint(certPem: string, expectedFingerprint: string): boolean {
+  const actual = computeFingerprint(certPem);
+  return crypto.timingSafeEqual(Buffer.from(actual, "hex"), Buffer.from(expectedFingerprint, "hex"));
+}

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -112,3 +112,10 @@ export const messageCreateSchema = z.object({
   signature: z.string().optional(),
   messageId: z.string().optional(),
 });
+
+// ── Certificate schemas (cloud-only) ──
+
+export const certificateCreateSchema = z.object({
+  name: z.string().min(1, "Name is required").max(100).transform((s) => s.trim()),
+  validityDays: z.number().int().min(1).max(3650).optional(),
+});


### PR DESCRIPTION
## Summary
Adds mutual TLS (mTLS) client certificate management as a cloud-only feature.

## Changes
- **Prisma**: `ClientCertificate` model with fingerprint, serial number, expiry, and revocation
- **`src/lib/mtls.cloud.ts`**: Certificate generation (node-forge RSA 2048), SHA-256 fingerprint, verification
- **API routes** (cloud-only, auth required):
  - `POST /api/v1/certificates` — generate new cert (returns PEM + private key)
  - `GET /api/v1/certificates` — list user's certificates
  - `DELETE /api/v1/certificates/[id]` — revoke a certificate
- **Dashboard**: `/dashboard/certificates` page with generate, download (.crt/.key), and revoke UI
- **Validation**: Zod `certificateCreateSchema`
- **Nav**: Added Certificates link to dashboard top-nav

## Notes
- All endpoints gated behind `isCloud()` — returns 403 for community edition
- Private key only shown once at generation time
- Certificates are self-signed (intended for Caddy mTLS client_auth)

Closes #42