### PR TITLE
feat: redesign CLI wizard

### DIFF
--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -1,51 +1,65 @@
 import * as http from "http";
-import { readPid, isProcessRunning, isInitialized } from "../lib/config";
+import * as fs from "fs";
+import * as path from "path";
+import { readPid, isProcessRunning, isInitialized, getAppDir, getEnvFile } from "../lib/config";
+import { color, printDivider } from "../lib/ui";
 
 function checkHealth(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const req = http.get(
       `http://localhost:${port}/api/health`,
-      { timeout: 5000 },
-      (res) => {
-        resolve(res.statusCode === 200);
-      }
+      { timeout: 3000 },
+      (res) => resolve(res.statusCode === 200)
     );
     req.on("error", () => resolve(false));
-    req.on("timeout", () => {
-      req.destroy();
-      resolve(false);
-    });
+    req.on("timeout", () => { req.destroy(); resolve(false); });
   });
 }
 
+function readPort(): number | null {
+  try {
+    const envFile = path.join(getAppDir(), ".env");
+    const fallback = getEnvFile();
+    const file = fs.existsSync(envFile) ? envFile : fallback;
+    const content = fs.readFileSync(file, "utf8");
+    const match = content.match(/^PORT=(\d+)/m);
+    return match ? parseInt(match[1], 10) : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function status(): Promise<void> {
+  console.log("");
+
   if (!isInitialized()) {
-    console.log("  HeySummon is not initialized. Run 'heysummon init' first.");
+    console.log(`  ${color.yellow("○")} Not installed`);
+    console.log(`  ${color.dim("Run")} ${color.cyan("npx heysummon")} ${color.dim("to get started.")}`);
+    console.log("");
     return;
   }
 
   const pid = readPid();
   const running = pid !== null && isProcessRunning(pid);
+  const port = readPort() || 3000;
 
+  printDivider();
+  console.log(`  ${color.bold("HeySummon Status")}`);
+  printDivider();
   console.log("");
-  console.log(`  HeySummon Status`);
-  console.log(`  ================`);
-  console.log(`  Initialized: yes`);
-  console.log(`  Process:     ${running ? `running (PID: ${pid})` : "stopped"}`);
 
   if (running) {
-    // Try common ports
-    for (const port of [3000, 3001, 8080]) {
-      const healthy = await checkHealth(port);
-      if (healthy) {
-        console.log(`  Health:      ok (port ${port})`);
-        console.log(`  URL:         http://localhost:${port}`);
-        console.log("");
-        return;
-      }
-    }
-    console.log(`  Health:      unreachable`);
+    const healthy = await checkHealth(port);
+    console.log(`  ${color.green("●")} ${color.bold("Running")} ${color.dim(`(PID: ${pid})`)}`);
+    console.log(`  ${color.dim("Health:")}  ${healthy ? color.green("ok") : color.yellow("unreachable")}`);
+    console.log(`  ${color.dim("URL:")}     ${color.cyan(`http://localhost:${port}`)}`);
+    console.log(`  ${color.dim("Logs:")}    ${color.cyan("pm2 logs heysummon")}`);
+  } else {
+    console.log(`  ${color.dim("○")} ${color.bold("Stopped")}`);
+    console.log(`  ${color.dim("Run")} ${color.cyan("heysummon start -d")} ${color.dim("to start.")}`);
   }
 
+  console.log("");
+  printDivider();
   console.log("");
 }

--- a/cli/src/lib/ui.ts
+++ b/cli/src/lib/ui.ts
@@ -1,0 +1,64 @@
+// ANSI color helpers — no dependencies needed
+const c = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  magenta: "\x1b[35m",
+  cyan: "\x1b[36m",
+  white: "\x1b[37m",
+  bgBlack: "\x1b[40m",
+};
+
+export const color = {
+  bold: (s: string) => `${c.bold}${s}${c.reset}`,
+  dim: (s: string) => `${c.dim}${s}${c.reset}`,
+  green: (s: string) => `${c.green}${s}${c.reset}`,
+  yellow: (s: string) => `${c.yellow}${s}${c.reset}`,
+  cyan: (s: string) => `${c.cyan}${s}${c.reset}`,
+  magenta: (s: string) => `${c.magenta}${s}${c.reset}`,
+  red: (s: string) => `${c.red}${s}${c.reset}`,
+  blue: (s: string) => `${c.blue}${s}${c.reset}`,
+  boldCyan: (s: string) => `${c.bold}${c.cyan}${s}${c.reset}`,
+  boldGreen: (s: string) => `${c.bold}${c.green}${s}${c.reset}`,
+  boldYellow: (s: string) => `${c.bold}${c.yellow}${s}${c.reset}`,
+};
+
+export function printBanner(): void {
+  console.log("");
+  console.log(`  ${color.boldCyan("🦞 HeySummon")} ${color.dim("v0.1.0-alpha")}`);
+  console.log(`  ${color.dim("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")}`);
+  console.log(`  ${color.bold("Human-in-the-Loop for AI agents")}`);
+  console.log("");
+  console.log(`  ${color.dim("Docs:")} ${color.cyan("https://docs.heysummon.ai")}`);
+  console.log(`  ${color.dim("Repo:")} ${color.cyan("https://github.com/thomasansems/heysummon")}`);
+  console.log("");
+}
+
+export function printStep(n: number, total: number, label: string): void {
+  console.log("");
+  console.log(`  ${color.boldCyan(`[${n}/${total}]`)} ${color.bold(label)}`);
+}
+
+export function printSuccess(msg: string): void {
+  console.log(`  ${color.green("✓")} ${msg}`);
+}
+
+export function printInfo(msg: string): void {
+  console.log(`  ${color.dim("·")} ${msg}`);
+}
+
+export function printWarning(msg: string): void {
+  console.log(`  ${color.yellow("⚠")} ${msg}`);
+}
+
+export function printError(msg: string): void {
+  console.log(`  ${color.red("✗")} ${msg}`);
+}
+
+export function printDivider(): void {
+  console.log(`  ${color.dim("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")}`);
+}


### PR DESCRIPTION
## Changes

- 🎨 **Kleurrijke output** via ANSI codes (geen extra dependencies)
- 📋 **Cleaner wizard** — 5 duidelijke stappen met uitleg per stap
- 🔗 **Docs link** aan het begin van de installer
- ❌ **GitHub/Google OAuth vragen verwijderd**
- 🔇 **Minder verbose** — npm/prisma/routes output gesuppressed
- ⚡ **PM2 first** — start automatisch via pm2 na install, fallback naar detached process
- 🖥️ **Standalone server** — gebruikt `node .next/standalone/server.js` i.p.v. `npm start`
- 🎯 **Status commando** verbeterd — toont URL, health, pm2 logs hint