### PR TITLE
fix: proxy.ts export name (fixes E2E CI build failure)

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -64,7 +64,7 @@ function applySecurityHeaders(response: NextResponse): NextResponse {
   return response;
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const ip = getClientIp(request);
 


### PR DESCRIPTION
Next.js 16 requires the function export in `proxy.ts` to be named `proxy`, not `middleware`. This was causing the E2E build to fail with:

```
Proxy is missing expected function export name
```

Fixes CI on PR #93.