### PR TITLE
feat: data retention — auto-cleanup job, admin API, dashboard UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,3 +82,7 @@ CONNECTIVITY_METHOD=direct
 
 # Edition: "community" (default, self-hosted) or "cloud" (managed, requires cloud license)
 HEYSUMMON_EDITION=community
+
+# Data retention — auto-delete expired/closed requests and audit logs older than X days
+# Default: not set = unlimited (nothing is deleted automatically)
+# HEYSUMMON_RETENTION_DAYS=90

--- a/src/app/api/admin/retention/route.ts
+++ b/src/app/api/admin/retention/route.ts
@@ -1,0 +1,44 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { runCleanup } from "@/lib/retention";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET /api/admin/retention — get current retention stats
+ * POST /api/admin/retention — trigger manual cleanup
+ */
+
+export async function GET() {
+  const user = await getCurrentUser();
+  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+  const retentionDays = process.env.HEYSUMMON_RETENTION_DAYS
+    ? parseInt(process.env.HEYSUMMON_RETENTION_DAYS, 10)
+    : null;
+
+  const [totalRequests, expiredRequests, totalAuditLogs] = await Promise.all([
+    prisma.helpRequest.count(),
+    prisma.helpRequest.count({ where: { status: { in: ["expired", "closed"] } } }),
+    prisma.auditLog.count(),
+  ]);
+
+  return NextResponse.json({
+    retentionDays,
+    enabled: !!retentionDays,
+    stats: {
+      totalRequests,
+      expiredRequests,
+      totalAuditLogs,
+    },
+  });
+}
+
+export async function POST() {
+  const user = await getCurrentUser();
+  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+  await runCleanup();
+  return NextResponse.json({ ok: true, message: "Cleanup triggered" });
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,11 @@
+/**
+ * Next.js instrumentation file.
+ * Runs once on server startup (both dev and production).
+ * Used to start background jobs.
+ */
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { startRetentionJob } = await import("./lib/retention");
+    startRetentionJob();
+  }
+}

--- a/src/lib/retention.ts
+++ b/src/lib/retention.ts
@@ -1,0 +1,70 @@
+import { prisma } from "./prisma";
+
+const RETENTION_DAYS = process.env.HEYSUMMON_RETENTION_DAYS
+  ? parseInt(process.env.HEYSUMMON_RETENTION_DAYS, 10)
+  : null;
+
+const INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/**
+ * Run a single cleanup pass.
+ * Deletes expired/closed HelpRequests (+ Messages via cascade) and
+ * AuditLogs older than HEYSUMMON_RETENTION_DAYS.
+ *
+ * Does nothing if HEYSUMMON_RETENTION_DAYS is not set.
+ */
+export async function runCleanup(): Promise<void> {
+  if (!RETENTION_DAYS || isNaN(RETENTION_DAYS) || RETENTION_DAYS <= 0) {
+    return;
+  }
+
+  const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000);
+
+  try {
+    // Delete expired/closed requests older than cutoff
+    // Messages are deleted automatically via onDelete: Cascade
+    const { count: requestsDeleted } = await prisma.helpRequest.deleteMany({
+      where: {
+        status: { in: ["expired", "closed"] },
+        updatedAt: { lt: cutoff },
+      },
+    });
+
+    // Delete audit logs older than cutoff
+    const { count: logsDeleted } = await prisma.auditLog.deleteMany({
+      where: {
+        createdAt: { lt: cutoff },
+      },
+    });
+
+    if (requestsDeleted > 0 || logsDeleted > 0) {
+      console.log(
+        `[retention] Cleanup complete — removed ${requestsDeleted} request(s), ${logsDeleted} audit log(s) older than ${RETENTION_DAYS} days`
+      );
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.error(`[retention] Cleanup failed: ${message}`);
+  }
+}
+
+/**
+ * Start the background retention job.
+ * Runs immediately on startup, then every 24 hours.
+ * Safe to call multiple times — only registers once.
+ */
+let started = false;
+
+export function startRetentionJob(): void {
+  if (started) return;
+  if (!RETENTION_DAYS) return;
+
+  started = true;
+  console.log(`[retention] Data retention enabled — purging records older than ${RETENTION_DAYS} days`);
+
+  // Run immediately on startup
+  runCleanup();
+
+  // Then every 24 hours
+  setInterval(runCleanup, INTERVAL_MS);
+}


### PR DESCRIPTION
Closes #87

## What's included

### `src/lib/retention.ts`
- Background cleanup job, starts on server boot via `instrumentation.ts`
- Runs every 24 hours
- Controlled by `HEYSUMMON_RETENTION_DAYS` env var (default: not set = unlimited)
- Deletes `expired` / `closed` HelpRequests older than X days
- Messages deleted automatically via `onDelete: Cascade`
- Deletes AuditLogs older than X days
- Never touches `pending` / `reviewing` / `responded` requests

### `src/instrumentation.ts`
- Next.js instrumentation hook — registers the retention job on server startup

### `src/app/api/admin/retention/route.ts`
- `GET /api/admin/retention` — returns retention config + stats
- `POST /api/admin/retention` — triggers manual cleanup

### `src/app/dashboard/settings/page.tsx`
- New **Data Retention** section in dashboard settings
- Shows: total requests, expired/closed requests, audit log count
- "Run cleanup now" button when retention is enabled

### `.env.example`
- Added `HEYSUMMON_RETENTION_DAYS` documentation