### PR TITLE
feat: provider key IP binding + device secret security

### DIFF
--- a/prisma/migrations/20260228103819_add_delivered_at/migration.sql
+++ b/prisma/migrations/20260228103819_add_delivered_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "HelpRequest" ADD COLUMN "deliveredAt" DATETIME;

--- a/prisma/migrations/20260228104623_provider_ip_security/migration.sql
+++ b/prisma/migrations/20260228104623_provider_ip_security/migration.sql
@@ -1,0 +1,28 @@
+-- AlterTable
+ALTER TABLE "UserProfile" ADD COLUMN "deviceSecret" TEXT;
+ALTER TABLE "UserProfile" ADD COLUMN "machineId" TEXT;
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_IpEvent" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "apiKeyId" TEXT,
+    "profileId" TEXT,
+    "ip" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "attempts" INTEGER NOT NULL DEFAULT 1,
+    "firstSeen" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeen" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "IpEvent_apiKeyId_fkey" FOREIGN KEY ("apiKeyId") REFERENCES "ApiKey" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "IpEvent_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "UserProfile" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_IpEvent" ("apiKeyId", "attempts", "firstSeen", "id", "ip", "lastSeen", "status") SELECT "apiKeyId", "attempts", "firstSeen", "id", "ip", "lastSeen", "status" FROM "IpEvent";
+DROP TABLE "IpEvent";
+ALTER TABLE "new_IpEvent" RENAME TO "IpEvent";
+CREATE INDEX "IpEvent_apiKeyId_idx" ON "IpEvent"("apiKeyId");
+CREATE INDEX "IpEvent_profileId_idx" ON "IpEvent"("profileId");
+CREATE UNIQUE INDEX "IpEvent_apiKeyId_ip_key" ON "IpEvent"("apiKeyId", "ip");
+CREATE UNIQUE INDEX "IpEvent_profileId_ip_key" ON "IpEvent"("profileId", "ip");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,9 +73,12 @@ model UserProfile {
   quietHoursStart  String?
   quietHoursEnd    String?
   digestTime       String?
+  deviceSecret     String?
+  machineId        String?
   user             User              @relation(fields: [userId], references: [id])
   apiKeys          ApiKey[]
   channelProviders ChannelProvider[]
+  ipEvents         IpEvent[]
   createdAt        DateTime          @default(now())
 }
 
@@ -126,8 +129,10 @@ model ApiKey {
 
 model IpEvent {
   id        String   @id @default(cuid())
-  apiKeyId  String
-  apiKey    ApiKey   @relation(fields: [apiKeyId], references: [id], onDelete: Cascade)
+  apiKeyId  String?
+  apiKey    ApiKey?  @relation(fields: [apiKeyId], references: [id], onDelete: Cascade)
+  profileId String?
+  profile   UserProfile? @relation(fields: [profileId], references: [id], onDelete: Cascade)
   ip        String
   status    String   @default("pending") // "allowed" | "pending" | "blacklisted"
   attempts  Int      @default(1)
@@ -135,7 +140,9 @@ model IpEvent {
   lastSeen  DateTime @default(now())
 
   @@unique([apiKeyId, ip])
+  @@unique([profileId, ip])
   @@index([apiKeyId])
+  @@index([profileId])
 }
 
 model HelpRequest {
@@ -166,6 +173,7 @@ model HelpRequest {
   guardVerified          Boolean   @default(false) // true if content was validated by guard sidecar
   
   status                 String    @default("pending") // pending | active | closed | expired
+  deliveredAt            DateTime? // When provider watcher acknowledged receipt
   expiresAt              DateTime  // createdAt + 72 hours
   closedAt               DateTime?
   

--- a/src/app/api/providers/ip-events/[eventId]/route.ts
+++ b/src/app/api/providers/ip-events/[eventId]/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * PATCH /api/providers/ip-events/:eventId — Update IP event status (allow/blacklist)
+ * DELETE /api/providers/ip-events/:eventId — Delete an IP event
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ eventId: string }> }
+) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { eventId } = await params;
+  const body = await request.json();
+  const { status } = body;
+
+  if (!["allowed", "pending", "blacklisted"].includes(status)) {
+    return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+  }
+
+  // Verify the event belongs to a profile owned by this user
+  const event = await prisma.ipEvent.findUnique({
+    where: { id: eventId },
+    include: { profile: { select: { userId: true } } },
+  });
+
+  if (!event || !event.profile || event.profile.userId !== user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const updated = await prisma.ipEvent.update({
+    where: { id: eventId },
+    data: { status, attempts: status === "allowed" ? 0 : undefined },
+  });
+
+  return NextResponse.json({ event: updated });
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ eventId: string }> }
+) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { eventId } = await params;
+
+  const event = await prisma.ipEvent.findUnique({
+    where: { id: eventId },
+    include: { profile: { select: { userId: true } } },
+  });
+
+  if (!event || !event.profile || event.profile.userId !== user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  await prisma.ipEvent.delete({ where: { id: eventId } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/providers/ip-events/route.ts
+++ b/src/app/api/providers/ip-events/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET /api/providers/ip-events — List IP events for all provider profiles of the current user
+ */
+export async function GET() {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const profiles = await prisma.userProfile.findMany({
+    where: { userId: user.id },
+    select: {
+      id: true,
+      name: true,
+      key: true,
+      ipEvents: {
+        orderBy: { lastSeen: "desc" },
+      },
+    },
+  });
+
+  return NextResponse.json({ profiles });
+}

--- a/src/lib/api-key-auth.ts
+++ b/src/lib/api-key-auth.ts
@@ -205,7 +205,10 @@ export async function validateApiKeyRequest(
           return {
             ok: false,
             response: NextResponse.json(
-              { error: "IP address is blacklisted" },
+              {
+                error: "IP address is blacklisted for this API key",
+                hint: "To unblock this IP, go to your HeySummon dashboard → Clients → select the key → IP Security and remove or allow this IP address.",
+              },
               { status: 403 }
             ),
           };
@@ -226,7 +229,11 @@ export async function validateApiKeyRequest(
           return {
             ok: false,
             response: NextResponse.json(
-              { error: "IP address not authorized for this key" },
+              {
+                error: "IP address not authorized for this API key",
+                hint: `This IP (${clientIp}) is pending approval. Go to your HeySummon dashboard → Clients → select the key → IP Security to allow it.`,
+                ip: clientIp,
+              },
               { status: 403 }
             ),
           };
@@ -251,7 +258,11 @@ export async function validateApiKeyRequest(
         return {
           ok: false,
           response: NextResponse.json(
-            { error: "IP address not authorized for this key" },
+            {
+              error: "IP address not authorized for this API key",
+              hint: `New IP detected (${clientIp}). Go to your HeySummon dashboard → Clients → select the key → IP Security to allow it.`,
+              ip: clientIp,
+            },
             { status: 403 }
           ),
         };

--- a/src/lib/provider-key-auth.ts
+++ b/src/lib/provider-key-auth.ts
@@ -1,0 +1,201 @@
+import { NextResponse } from "next/server";
+import { prisma } from "./prisma";
+import crypto from "crypto";
+
+const AUTO_BLACKLIST_THRESHOLD = 20;
+
+/**
+ * Hash a device token using SHA-256.
+ */
+export function hashDeviceToken(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+/**
+ * Extract client IP from request headers.
+ */
+function getClientIp(request: Request): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown"
+  );
+}
+
+/**
+ * Validate a provider key (hs_prov_...) with IP binding and device secret.
+ *
+ * Flow:
+ *   1. Lookup provider by key
+ *   2. IP auto-bind (first request binds IP, new IPs go to "pending")
+ *   3. Device secret validation (if set)
+ *   4. Machine ID binding (if provided)
+ *
+ * Error messages include instructions to manage IPs/devices in the dashboard.
+ */
+export async function validateProviderKey(
+  request: Request
+): Promise<
+  | { ok: true; provider: { id: string; userId: string; name: string } }
+  | { ok: false; response: NextResponse }
+> {
+  const apiKey = request.headers.get("x-api-key");
+
+  if (!apiKey) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "x-api-key header required" },
+        { status: 401 }
+      ),
+    };
+  }
+
+  const provider = await prisma.userProfile.findFirst({
+    where: { key: apiKey, isActive: true },
+    select: {
+      id: true,
+      userId: true,
+      name: true,
+      deviceSecret: true,
+      machineId: true,
+    },
+  });
+
+  if (!provider) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Invalid or inactive provider key" },
+        { status: 401 }
+      ),
+    };
+  }
+
+  // ── IP auto-bind ──
+  const clientIp = getClientIp(request);
+  const existingEvents = await prisma.ipEvent.findMany({
+    where: { profileId: provider.id },
+  });
+
+  if (existingEvents.length === 0) {
+    // First ever request — bind this IP as allowed
+    await prisma.ipEvent.create({
+      data: { profileId: provider.id, ip: clientIp, status: "allowed" },
+    });
+  } else {
+    const matchingEvent = existingEvents.find((e) => e.ip === clientIp);
+
+    if (matchingEvent) {
+      if (matchingEvent.status === "blacklisted") {
+        return {
+          ok: false,
+          response: NextResponse.json(
+            {
+              error: "IP address is blacklisted for this provider key",
+              hint: "To unblock this IP, go to your HeySummon dashboard → Settings → IP Security and remove or allow this IP address.",
+            },
+            { status: 403 }
+          ),
+        };
+      }
+      if (matchingEvent.status === "pending") {
+        const newAttempts = matchingEvent.attempts + 1;
+        await prisma.ipEvent.update({
+          where: { id: matchingEvent.id },
+          data: {
+            attempts: newAttempts,
+            lastSeen: new Date(),
+            ...(newAttempts >= AUTO_BLACKLIST_THRESHOLD
+              ? { status: "blacklisted" }
+              : {}),
+          },
+        });
+        return {
+          ok: false,
+          response: NextResponse.json(
+            {
+              error: "IP address not authorized for this provider key",
+              hint: `This IP (${clientIp}) is pending approval. Go to your HeySummon dashboard → Settings → IP Security to allow it.`,
+              ip: clientIp,
+            },
+            { status: 403 }
+          ),
+        };
+      }
+      // status === "allowed" → pass through
+    } else {
+      // New unknown IP → create as pending
+      await prisma.ipEvent.upsert({
+        where: {
+          profileId_ip: { profileId: provider.id, ip: clientIp },
+        },
+        create: {
+          profileId: provider.id,
+          ip: clientIp,
+          status: "pending",
+        },
+        update: {
+          attempts: { increment: 1 },
+          lastSeen: new Date(),
+        },
+      });
+      return {
+        ok: false,
+        response: NextResponse.json(
+          {
+            error: "IP address not authorized for this provider key",
+            hint: `New IP detected (${clientIp}). Go to your HeySummon dashboard → Settings → IP Security to allow it.`,
+            ip: clientIp,
+          },
+          { status: 403 }
+        ),
+      };
+    }
+  }
+
+  // ── Device secret validation ──
+  if (provider.deviceSecret) {
+    const deviceToken = request.headers.get("x-device-token");
+    if (!deviceToken || hashDeviceToken(deviceToken) !== provider.deviceSecret) {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          {
+            error: "Invalid or missing device token",
+            hint: "This provider key requires a device token. Include x-device-token header with the secret generated during setup.",
+          },
+          { status: 403 }
+        ),
+      };
+    }
+  }
+
+  // ── Machine ID binding ──
+  const machineId = request.headers.get("x-machine-id");
+
+  if (provider.machineId) {
+    if (!machineId || machineId !== provider.machineId) {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          {
+            error: "Machine fingerprint mismatch. This provider key is bound to another device.",
+            hint: "To rebind to a new device, go to your HeySummon dashboard → Settings and reset the machine binding.",
+          },
+          { status: 403 }
+        ),
+      };
+    }
+  } else if (machineId) {
+    await prisma.userProfile.update({
+      where: { id: provider.id },
+      data: { machineId },
+    });
+  }
+
+  return {
+    ok: true,
+    provider: { id: provider.id, userId: provider.userId, name: provider.name },
+  };
+}


### PR DESCRIPTION
## Problem
Provider keys (`hs_prov_...`) had zero security — anyone with the key could read all SSE events and see help requests. Client keys already had IP binding, device secrets, and rate limiting, but provider keys had none of that.

## Solution
Mirror the client key security system for provider keys:

### IP Auto-bind (A)
- First request with a provider key → auto-binds that IP as `allowed`
- Subsequent requests from new IPs → `pending` status (blocked)
- After 20 attempts from a pending IP → auto-blacklisted
- Provider must approve new IPs via **Settings → Provider IP Security**

### Device Secret (B)
- `deviceSecret` and `machineId` fields added to `UserProfile`
- If set, watcher must send `x-device-token` and/or `x-machine-id` headers
- Prevents stolen key from working on a different device

### Error messages with hints
All IP/device errors now include a `hint` field telling the user exactly where to go:
```json
{
  "error": "IP address not authorized for this provider key",
  "hint": "New IP detected (192.168.1.5). Go to your HeySummon dashboard → Settings → IP Security to allow it.",
  "ip": "192.168.1.5"
}
```
This also applies to **client keys** now (same hint pattern).

### Dashboard UI
- New **Provider IP Security** section in Settings
- Per-profile IP event list with Allow / Block / Delete buttons
- Shows attempt count and last seen timestamp

## Files
- `src/lib/provider-key-auth.ts` — new validation module
- `src/lib/api-key-auth.ts` — improved error messages with hints
- `src/app/api/v1/events/stream/route.ts` — uses provider validation
- `src/app/api/providers/ip-events/` — management endpoints
- `src/app/dashboard/settings/page.tsx` — IP Security UI
- `prisma/schema.prisma` — IpEvent.profileId + UserProfile.deviceSecret/machineId