### PR TITLE
feat: IP Security inline panel on providers page

### DIFF
--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -10,7 +10,10 @@ export async function GET() {
 
   const providers = await prisma.userProfile.findMany({
     where: { userId: user.id },
-    include: { _count: { select: { apiKeys: true } } },
+    include: {
+      _count: { select: { apiKeys: true } },
+      ipEvents: { orderBy: { lastSeen: "desc" } },
+    },
     orderBy: { createdAt: "desc" },
   });
 

--- a/src/app/dashboard/providers/page.tsx
+++ b/src/app/dashboard/providers/page.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { copyToClipboard } from "@/lib/clipboard";
+import { Fragment, useEffect, useState } from "react";
 
-import { useEffect, useState } from "react";
+interface IpEvent {
+  id: string;
+  ip: string;
+  status: string;
+  attempts: number;
+  firstSeen: string;
+  lastSeen: string;
+}
 
 interface Provider {
   id: string;
@@ -10,26 +18,29 @@ interface Provider {
   key: string;
   isActive: boolean;
   createdAt: string;
+  ipEvents: IpEvent[];
   _count: { apiKeys: number };
 }
 
 export default function ProvidersPage() {
   const [providers, setProviders] = useState<Provider[]>([]);
+  const [loading, setLoading] = useState(true);
   const [newName, setNewName] = useState("");
   const [creating, setCreating] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [copied, setCopied] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
+  const [settingsId, setSettingsId] = useState<string | null>(null);
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
 
   const loadProviders = () =>
     fetch("/api/providers")
       .then((r) => { if (!r.ok) throw new Error(r.statusText); return r.json(); })
-      .then((data) => setProviders(data.providers || []));
+      .then((data) => { setProviders(data.providers || []); setLoading(false); })
+      .catch(() => setLoading(false));
 
-  useEffect(() => {
-    loadProviders();
-  }, []);
+  useEffect(() => { loadProviders(); }, []);
 
   const createProvider = async () => {
     if (!newName.trim()) return;
@@ -46,20 +57,28 @@ export default function ProvidersPage() {
   };
 
   const toggleProvider = async (id: string, isActive: boolean) => {
-    await fetch(`/api/providers/${id}`, { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ isActive }) });
+    await fetch(`/api/providers/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ isActive }),
+    });
     loadProviders();
   };
 
   const renameProvider = async (id: string) => {
     if (!editName.trim()) return;
-    await fetch(`/api/providers/${id}`, { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name: editName.trim() }) });
+    await fetch(`/api/providers/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: editName.trim() }),
+    });
     setEditingId(null);
     setEditName("");
     loadProviders();
   };
 
   const deleteProvider = async (id: string, name: string) => {
-    if (!window.confirm(`Are you sure you want to permanently delete user "${name}"? All linked clients will be unlinked. This cannot be undone.`)) return;
+    if (!window.confirm(`Are you sure you want to permanently delete "${name}"?\n\nAll linked clients will be unlinked. This cannot be undone.`)) return;
     await fetch(`/api/providers/${id}`, { method: "DELETE" });
     loadProviders();
   };
@@ -72,6 +91,10 @@ export default function ProvidersPage() {
 
   const masked = (key: string) =>
     key.slice(0, 12) + "•".repeat(16) + key.slice(-4);
+
+  const openSettings = (p: Provider) => {
+    setSettingsId(settingsId === p.id ? null : p.id);
+  };
 
   return (
     <div>
@@ -113,8 +136,33 @@ export default function ProvidersPage() {
         </div>
       )}
 
-      <div className="overflow-hidden rounded-lg border border-[#eaeaea] bg-white">
-        {providers.length === 0 ? (
+      <div className="overflow-visible rounded-lg border border-[#eaeaea] bg-white">
+        {loading ? (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[#eaeaea] text-left text-[#666]">
+                <th className="px-4 py-2.5 font-medium">Name</th>
+                <th className="px-4 py-2.5 font-medium">User Key</th>
+                <th className="px-4 py-2.5 font-medium">Clients</th>
+                <th className="px-4 py-2.5 font-medium">Status</th>
+                <th className="px-4 py-2.5 font-medium">Created</th>
+                <th className="px-4 py-2.5 font-medium" />
+              </tr>
+            </thead>
+            <tbody>
+              {[1, 2, 3].map((i) => (
+                <tr key={i} className="border-b border-[#eaeaea] animate-pulse">
+                  <td className="px-4 py-2.5"><div className="h-4 w-24 rounded bg-[#eaeaea]" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-36 rounded bg-[#eaeaea]" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-8 rounded bg-[#eaeaea]" /></td>
+                  <td className="px-4 py-2.5"><div className="h-5 w-16 rounded-full bg-[#eaeaea]" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-20 rounded bg-[#eaeaea]" /></td>
+                  <td className="px-4 py-2.5 text-right"><div className="ml-auto h-6 w-8 rounded bg-[#eaeaea]" /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : providers.length === 0 ? (
           <div className="p-8 text-center text-sm text-[#666]">
             No providers yet. Create one to get started.
           </div>
@@ -125,76 +173,241 @@ export default function ProvidersPage() {
                 <th className="px-4 py-2.5 font-medium">Name</th>
                 <th className="px-4 py-2.5 font-medium">User Key</th>
                 <th className="px-4 py-2.5 font-medium">Clients</th>
-                <th className="px-4 py-2.5 font-medium">Status</th>
+                <th className="px-4 py-2.5 font-medium">IP Status</th>
                 <th className="px-4 py-2.5 font-medium">Created</th>
-                <th className="px-4 py-2.5 font-medium text-right">Actions</th>
+                <th className="px-4 py-2.5 font-medium" />
               </tr>
             </thead>
             <tbody>
               {providers.map((p) => (
-                <tr
-                  key={p.id}
-                  className="border-b border-[#eaeaea] last:border-0"
-                >
-                  <td className="px-4 py-2.5 font-medium text-black">
-                    {editingId === p.id ? (
-                      <div className="flex items-center gap-1">
-                        <input
-                          value={editName}
-                          onChange={(e) => setEditName(e.target.value)}
-                          onKeyDown={(e) => { if (e.key === "Enter") renameProvider(p.id); if (e.key === "Escape") setEditingId(null); }}
-                          className="w-32 rounded border border-[#eaeaea] px-2 py-0.5 text-sm outline-none focus:border-black"
-                          autoFocus
-                        />
-                        <button onClick={() => renameProvider(p.id)} className="text-xs text-green-600">✓</button>
-                        <button onClick={() => setEditingId(null)} className="text-xs text-[#666]">✕</button>
-                      </div>
-                    ) : (
-                      <span
-                        className="cursor-pointer hover:underline"
-                        onClick={() => { setEditingId(p.id); setEditName(p.name); }}
-                        title="Click to rename"
-                      >
-                        {p.name}
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-4 py-2.5">
-                    <div className="flex items-center gap-2">
-                      <code className="font-mono text-xs text-[#666]">
-                        {masked(p.key)}
-                      </code>
-                      <button
-                        onClick={() => copyKey(p.key)}
-                        className="text-xs text-violet-600 hover:text-violet-800"
-                      >
-                        {copied === p.key ? "Copied!" : "Copy"}
-                      </button>
-                    </div>
-                  </td>
-                  <td className="px-4 py-2.5 text-[#666]">
-                    {p._count.apiKeys}
-                  </td>
-                  <td className="px-4 py-2.5">
-                    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${p.isActive ? "bg-green-50 text-green-700" : "bg-red-50 text-red-700"}`}>
-                      {p.isActive ? "Active" : "Inactive"}
-                    </span>
-                  </td>
-                  <td className="px-4 py-2.5 text-[#666]">
-                    {new Date(p.createdAt).toLocaleDateString()}
-                  </td>
-                  <td className="px-4 py-2.5 text-right">
-                    <div className="flex items-center justify-end gap-2">
-                      <a href={`/dashboard/providers/${p.id}/settings`} className="text-xs text-violet-600 hover:text-violet-800">Settings</a>
-                      {p.isActive ? (
-                        <button onClick={() => toggleProvider(p.id, false)} className="text-xs text-red-500 hover:text-red-700">Deactivate</button>
+                <Fragment key={p.id}>
+                  <tr className="border-b border-[#eaeaea] last:border-0">
+                    <td className="px-4 py-2.5 font-medium text-black">
+                      {editingId === p.id ? (
+                        <div className="flex items-center gap-1">
+                          <input
+                            value={editName}
+                            onChange={(e) => setEditName(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter") renameProvider(p.id);
+                              if (e.key === "Escape") setEditingId(null);
+                            }}
+                            className="w-32 rounded border border-[#eaeaea] px-2 py-0.5 text-sm outline-none focus:border-black"
+                            autoFocus
+                          />
+                          <button onClick={() => renameProvider(p.id)} className="text-xs text-green-600">✓</button>
+                          <button onClick={() => setEditingId(null)} className="text-xs text-[#666]">✕</button>
+                        </div>
                       ) : (
-                        <button onClick={() => toggleProvider(p.id, true)} className="text-xs text-green-600 hover:text-green-800">Activate</button>
+                        <span
+                          className="cursor-pointer hover:underline"
+                          onClick={() => { setEditingId(p.id); setEditName(p.name); }}
+                          title="Click to rename"
+                        >
+                          {p.name}
+                        </span>
                       )}
-                      <button onClick={() => deleteProvider(p.id, p.name)} className="text-base text-black hover:text-red-600" title="Delete">✕</button>
-                    </div>
-                  </td>
-                </tr>
+                    </td>
+
+                    <td className="px-4 py-2.5">
+                      <div className="flex items-center gap-2">
+                        <code className="font-mono text-xs text-[#666]">{masked(p.key)}</code>
+                        <button
+                          onClick={() => copyKey(p.key)}
+                          className="text-xs text-violet-600 hover:text-violet-800"
+                        >
+                          {copied === p.key ? "Copied!" : "Copy"}
+                        </button>
+                      </div>
+                    </td>
+
+                    <td className="px-4 py-2.5 text-[#666]">{p._count.apiKeys}</td>
+
+                    <td className="px-4 py-2.5">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                          !p.isActive
+                            ? "bg-red-50 text-red-700"
+                            : p.ipEvents?.some((e) => e.status === "allowed")
+                              ? "bg-green-50 text-green-700"
+                              : "bg-orange-50 text-orange-700"
+                        }`}
+                      >
+                        {!p.isActive
+                          ? "Inactive"
+                          : p.ipEvents?.some((e) => e.status === "allowed")
+                            ? "Bound"
+                            : "No binding yet"}
+                      </span>
+                    </td>
+
+                    <td className="px-4 py-2.5 text-[#666]">
+                      {new Date(p.createdAt).toLocaleDateString()}
+                    </td>
+
+                    <td className="px-4 py-2.5 text-right">
+                      <div className="relative inline-block">
+                        <button
+                          onClick={() => setOpenMenuId(openMenuId === p.id ? null : p.id)}
+                          className="rounded-md border border-[#eaeaea] px-2 py-1 text-xs text-[#666] hover:bg-[#fafafa] hover:text-black"
+                        >
+                          ⋯
+                        </button>
+                        {openMenuId === p.id && (
+                          <div className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded-lg border border-[#eaeaea] bg-white py-1 shadow-lg">
+                            <button
+                              onClick={() => { openSettings(p); setOpenMenuId(null); }}
+                              className="block w-full px-3 py-1.5 text-left text-xs text-[#666] hover:bg-[#fafafa] hover:text-black"
+                            >
+                              IP Security
+                            </button>
+                            <a
+                              href={`/dashboard/providers/${p.id}/settings`}
+                              className="block w-full px-3 py-1.5 text-left text-xs text-[#666] hover:bg-[#fafafa] hover:text-black"
+                              onClick={() => setOpenMenuId(null)}
+                            >
+                              Settings
+                            </a>
+                            {p.isActive ? (
+                              <button
+                                onClick={() => { toggleProvider(p.id, false); setOpenMenuId(null); }}
+                                className="block w-full px-3 py-1.5 text-left text-xs text-red-500 hover:bg-[#fafafa] hover:text-red-700"
+                              >
+                                Deactivate
+                              </button>
+                            ) : (
+                              <button
+                                onClick={() => { toggleProvider(p.id, true); setOpenMenuId(null); }}
+                                className="block w-full px-3 py-1.5 text-left text-xs text-green-600 hover:bg-[#fafafa] hover:text-green-800"
+                              >
+                                Activate
+                              </button>
+                            )}
+                            <div className="my-1 border-t border-[#eaeaea]" />
+                            <button
+                              onClick={() => { deleteProvider(p.id, p.name); setOpenMenuId(null); }}
+                              className="block w-full px-3 py-1.5 text-left text-xs text-red-500 hover:bg-red-50 hover:text-red-700"
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+
+                  {/* IP Security inline panel */}
+                  {settingsId === p.id && (
+                    <tr key={`${p.id}-settings`} className="border-b border-[#eaeaea]">
+                      <td colSpan={6} className="bg-[#fafafa] px-4 py-3">
+                        <div className="flex items-center justify-between mb-2">
+                          <p className="text-xs font-medium text-[#666]">IP Security</p>
+                          {p.ipEvents?.length > 0 && (
+                            <button
+                              onClick={async () => {
+                                if (!window.confirm("Reset all IP bindings for this provider? The next request will bind a new IP.")) return;
+                                await Promise.all(
+                                  p.ipEvents.map((evt) =>
+                                    fetch(`/api/providers/ip-events/${evt.id}`, { method: "DELETE" })
+                                  )
+                                );
+                                loadProviders();
+                              }}
+                              className="rounded-md border border-red-200 px-2 py-0.5 text-xs text-red-600 hover:bg-red-50"
+                            >
+                              Reset All Bindings
+                            </button>
+                          )}
+                        </div>
+
+                        {!p.ipEvents || p.ipEvents.length === 0 ? (
+                          <p className="text-xs text-[#999]">
+                            No IP bindings yet. The first API request from this provider will automatically bind its IP.
+                          </p>
+                        ) : (
+                          <table className="w-full text-xs">
+                            <thead>
+                              <tr className="text-left text-[#999]">
+                                <th className="pb-1 pr-4 font-medium">IP Address</th>
+                                <th className="pb-1 pr-4 font-medium">Status</th>
+                                <th className="pb-1 pr-4 font-medium">Attempts</th>
+                                <th className="pb-1 pr-4 font-medium">First Seen</th>
+                                <th className="pb-1 pr-4 font-medium">Last Seen</th>
+                                <th className="pb-1 font-medium" />
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {p.ipEvents.map((evt) => (
+                                <tr key={evt.id} className="border-t border-[#eaeaea]">
+                                  <td className="py-1.5 pr-4 font-mono text-[#666]">{evt.ip}</td>
+                                  <td className="py-1.5 pr-4">
+                                    <span
+                                      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                                        evt.status === "allowed"
+                                          ? "bg-green-50 text-green-700"
+                                          : evt.status === "pending"
+                                            ? "bg-amber-50 text-amber-700"
+                                            : "bg-red-50 text-red-700"
+                                      }`}
+                                    >
+                                      {evt.status}
+                                    </span>
+                                  </td>
+                                  <td className="py-1.5 pr-4 text-[#666]">{evt.attempts}</td>
+                                  <td className="py-1.5 pr-4 text-[#666]">{new Date(evt.firstSeen).toLocaleString()}</td>
+                                  <td className="py-1.5 pr-4 text-[#666]">{new Date(evt.lastSeen).toLocaleString()}</td>
+                                  <td className="py-1.5 text-right">
+                                    <div className="flex items-center justify-end gap-1">
+                                      {evt.status !== "allowed" && (
+                                        <button
+                                          onClick={async () => {
+                                            await fetch(`/api/providers/ip-events/${evt.id}`, {
+                                              method: "PATCH",
+                                              headers: { "Content-Type": "application/json" },
+                                              body: JSON.stringify({ status: "allowed" }),
+                                            });
+                                            loadProviders();
+                                          }}
+                                          className="rounded px-1.5 py-0.5 text-xs text-green-600 hover:bg-green-50"
+                                        >
+                                          Allow
+                                        </button>
+                                      )}
+                                      {evt.status !== "blacklisted" && (
+                                        <button
+                                          onClick={async () => {
+                                            await fetch(`/api/providers/ip-events/${evt.id}`, {
+                                              method: "PATCH",
+                                              headers: { "Content-Type": "application/json" },
+                                              body: JSON.stringify({ status: "blacklisted" }),
+                                            });
+                                            loadProviders();
+                                          }}
+                                          className="rounded px-1.5 py-0.5 text-xs text-red-600 hover:bg-red-50"
+                                        >
+                                          Blacklist
+                                        </button>
+                                      )}
+                                      <button
+                                        onClick={async () => {
+                                          await fetch(`/api/providers/ip-events/${evt.id}`, { method: "DELETE" });
+                                          loadProviders();
+                                        }}
+                                        className="rounded px-1.5 py-0.5 text-xs text-[#999] hover:bg-[#f0f0f0] hover:text-[#666]"
+                                      >
+                                        Remove
+                                      </button>
+                                    </div>
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
               ))}
             </tbody>
           </table>


### PR DESCRIPTION
Connects Provider IP Security to the /dashboard/providers page, same pattern as /dashboard/clients.

**Changes:**
- `/api/providers` GET now includes `ipEvents` per provider
- Providers table: new **IP Status** column (Bound / No binding yet / Inactive)
- ⋯ dropdown menu with: IP Security, Settings, Activate/Deactivate, Delete
- Inline expandable **IP Security panel** per provider row:
  - IP address, status badge, attempts, first/last seen
  - Allow / Blacklist / Remove per event
  - Reset All Bindings button