### PR TITLE
chore: remove Tailscale from Docker Compose files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,15 +66,13 @@ GUARD_PUBLIC_KEY=
 REQUIRE_GUARD=true
 
 # ─── Connectivity ─────────────────────────────────────
-# Method: cloudflare, tailscale, ngrok, or direct (default)
+# Method: cloudflare, ngrok, or direct (default)
 # Use Docker Compose profiles: docker compose --profile cloudflare up -d
 CONNECTIVITY_METHOD=direct
 
 # Cloudflare Tunnel (--profile cloudflare)
 # CLOUDFLARE_TUNNEL_TOKEN=
 
-# Tailscale Funnel (--profile tailscale)
-# TAILSCALE_AUTHKEY=
 
 # Ngrok (--profile ngrok)
 # NGROK_AUTHTOKEN=

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,6 @@
 # Tunnel profiles:
 #   docker compose -f docker-compose.dev.yml --profile ngrok up -d
 #   docker compose -f docker-compose.dev.yml --profile cloudflare up -d
-#   docker compose -f docker-compose.dev.yml --profile tailscale up -d
 #
 # For production self-hosting (no source code needed), use docker-compose.yml instead.
 
@@ -179,37 +178,6 @@ services:
       retries: 3
       start_period: 15s
 
-  # Tailscale Funnel: docker compose -f docker-compose.dev.yml --profile tailscale up -d
-  tailscale:
-    image: tailscale/tailscale:latest
-    restart: unless-stopped
-    profiles: ["tailscale"]
-    hostname: heysummon
-    networks:
-      - frontend
-    depends_on:
-      heysummon-guard:
-        condition: service_healthy
-    environment:
-      TS_AUTHKEY: ${TAILSCALE_AUTHKEY:-}
-      TS_STATE_DIR: /var/lib/tailscale
-      TS_EXTRA_ARGS: --advertise-tags=tag:heysummon
-      TS_SERVE_CONFIG: /config/serve.json
-    volumes:
-      - tailscale-state:/var/lib/tailscale
-      - ./tailscale-config:/config:ro
-    cap_add:
-      - NET_ADMIN
-      - SYS_MODULE
-    devices:
-      - /dev/net/tun:/dev/net/tun
-    healthcheck:
-      test: ["CMD", "tailscale", "status", "--json"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-
   # Ngrok: docker compose -f docker-compose.dev.yml --profile ngrok up -d
   ngrok:
     image: ngrok/ngrok:latest
@@ -262,4 +230,3 @@ volumes:
   pgdata:
   guard-keys:
   heysummon-data:
-  tailscale-state:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -169,31 +169,6 @@ services:
     environment:
       TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN:-}
 
-  # Tailscale Funnel: docker compose -f docker-compose.prod.yml --profile tailscale up -d
-  tailscale:
-    image: tailscale/tailscale:latest
-    restart: unless-stopped
-    profiles: ["tailscale"]
-    hostname: heysummon
-    networks:
-      - frontend
-    depends_on:
-      heysummon-guard:
-        condition: service_healthy
-    environment:
-      TS_AUTHKEY: ${TAILSCALE_AUTHKEY:-}
-      TS_STATE_DIR: /var/lib/tailscale
-      TS_EXTRA_ARGS: --advertise-tags=tag:heysummon
-      TS_SERVE_CONFIG: /config/serve.json
-    volumes:
-      - tailscale-state:/var/lib/tailscale
-      - ./tailscale-config:/config:ro
-    cap_add:
-      - NET_ADMIN
-      - SYS_MODULE
-    devices:
-      - /dev/net/tun:/dev/net/tun
-
   # Ngrok: docker compose -f docker-compose.prod.yml --profile ngrok up -d
   ngrok:
     image: ngrok/ngrok:latest
@@ -220,4 +195,3 @@ networks:
 volumes:
   pgdata:
   guard-keys:
-  tailscale-state:


### PR DESCRIPTION
Closes #137

Removes the Tailscale service, volume, and all related references from both `docker-compose.dev.yml` and `docker-compose.prod.yml`, and cleans up `.env.example`.