### PR TITLE
fix: Vercel Prisma binary targets + explicit build command

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "rhel-openssl-1.0.x", "linux-musl-openssl-3.0.x"]
 }
 
 datasource db {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "prisma generate && next build",
+  "installCommand": "npm install"
+}


### PR DESCRIPTION
Fixes build error: 'Can't resolve @prisma/client' on Vercel.

- Added binaryTargets (native, rhel-openssl-1.0.x, linux-musl-openssl-3.0.x) to schema.prisma
- Added vercel.json with explicit buildCommand and installCommand