### PR TITLE
feat: Summoning Context -- provider-defined AI guidelines

### DIFF
--- a/prisma/migrations/20260330_add_summon_context/migration.sql
+++ b/prisma/migrations/20260330_add_summon_context/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "UserProfile" ADD COLUMN "summonContext" TEXT;
+
+-- AlterTable
+ALTER TABLE "SetupToken" ADD COLUMN "summonContext" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,6 +81,7 @@ model UserProfile {
   machineId        String?
   tagline          String?           // Optional upsell tagline appended to responses (max 160 chars)
   taglineEnabled   Boolean           @default(false)
+  summonContext    String?           // Advisory text for AI: when to summon this provider (max 500 chars)
   phoneFirst       Boolean           @default(false) // If true, attempt phone call before chat
   phoneFirstIntegrationId String?    // Which voice integration to use for phone-first
   phoneFirstTimeout       Int        @default(30)    // Seconds to wait for phone pickup before fallback
@@ -152,6 +153,7 @@ model SetupToken {
   channel       String                      // "openclaw" | "claudecode" | "codex" | "gemini" | "cursor"
   subChannel    String?                     // "telegram" | "whatsapp"
   providerName  String?
+  summonContext String?              // Copied from provider profile at link-creation time
   timeout       Int      @default(900)
   pollInterval  Int      @default(3)
   globalInstall Boolean  @default(true)

--- a/skills/heysummon/SKILL.md
+++ b/skills/heysummon/SKILL.md
@@ -51,6 +51,16 @@ bash $SKILL_DIR/scripts/check-status.sh <refCode|requestId>
 - **Provider unavailable**: The request is rejected and you are told when the provider will be available again. You can ask again at that time.
 - **`TIMEOUT`**: No response within 15 minutes. The request remains visible on the HeySummon dashboard. You can ask again if needed.
 
+## When to summon
+
+If `HEYSUMMON_SUMMON_CONTEXT` is set in your `.env`, follow those guidelines to decide when to summon the provider. The provider wrote these instructions specifically for you.
+
+If no summoning context is configured, use these defaults:
+- Summon when you are **stuck** and cannot proceed without human input
+- Summon when a decision requires **human judgment** (architecture, UX, business logic)
+- Summon when you need **approval** before a destructive or irreversible action
+- Do **not** summon for trivial questions you can resolve yourself
+
 ## Rules
 
 - **Always wait** for the response before continuing
@@ -64,4 +74,5 @@ HEYSUMMON_BASE_URL=http://localhost:3425
 HEYSUMMON_API_KEY=hs_cli_your_key_here
 HEYSUMMON_TIMEOUT=900
 HEYSUMMON_POLL_INTERVAL=3
+HEYSUMMON_SUMMON_CONTEXT=Only summon when stuck or need approval
 ```

--- a/skills/openclaw/heysummon/SKILL.md
+++ b/skills/openclaw/heysummon/SKILL.md
@@ -44,6 +44,16 @@ bash {baseDir}/scripts/check-status.sh <refCode|requestId>
 - **Provider unavailable**: The request is rejected and you are told when the provider will be available again. You can ask again at that time.
 - **`TIMEOUT`**: No response within 15 minutes. The request remains visible on the HeySummon dashboard. You can ask again if needed.
 
+## When to summon
+
+If `HEYSUMMON_SUMMON_CONTEXT` is set in your environment, follow those guidelines to decide when to summon the provider. The provider wrote these instructions specifically for you.
+
+If no summoning context is configured, use these defaults:
+- Summon when you are **stuck** and cannot proceed without human input
+- Summon when a decision requires **human judgment** (architecture, UX, business logic)
+- Summon when you need **approval** before a destructive or irreversible action
+- Do **not** summon for trivial questions you can resolve yourself
+
 ## Rules
 
 - **Always wait** for the response before continuing
@@ -57,4 +67,5 @@ HEYSUMMON_BASE_URL=http://localhost:3425
 HEYSUMMON_API_KEY=hs_cli_your_key_here
 HEYSUMMON_TIMEOUT=900
 HEYSUMMON_POLL_INTERVAL=3
+HEYSUMMON_SUMMON_CONTEXT=Only summon when stuck or need approval
 ```

--- a/src/__tests__/provider-summon-context.test.ts
+++ b/src/__tests__/provider-summon-context.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Tests for summonContext data transformation logic in the provider PATCH handler.
+ *
+ * The PATCH /api/providers/:id handler applies this transformation:
+ *   (body.summonContext as string)?.slice(0, 500) || null
+ *
+ * This test suite validates that transformation independently of the HTTP layer.
+ */
+
+/** Mirrors the PATCH handler's summonContext transformation */
+function transformSummonContext(value: unknown): string | null {
+  return (value as string)?.slice(0, 500) || null;
+}
+
+describe("Provider PATCH — summonContext transformation", () => {
+  it("passes through a normal string", () => {
+    const result = transformSummonContext("Only summon me for critical decisions.");
+    expect(result).toBe("Only summon me for critical decisions.");
+  });
+
+  it("truncates strings exceeding 500 characters", () => {
+    const long = "x".repeat(600);
+    const result = transformSummonContext(long);
+    expect(result).toHaveLength(500);
+    expect(result).toBe("x".repeat(500));
+  });
+
+  it("preserves strings at exactly 500 characters", () => {
+    const exact = "y".repeat(500);
+    const result = transformSummonContext(exact);
+    expect(result).toBe(exact);
+    expect(result).toHaveLength(500);
+  });
+
+  it("converts empty string to null", () => {
+    const result = transformSummonContext("");
+    expect(result).toBeNull();
+  });
+
+  it("converts null to null", () => {
+    const result = transformSummonContext(null);
+    expect(result).toBeNull();
+  });
+
+  it("converts undefined to null", () => {
+    const result = transformSummonContext(undefined);
+    expect(result).toBeNull();
+  });
+
+  it("preserves special characters without escaping", () => {
+    const context = `Before any $() action; use 'single' & "double" quotes <safely>.`;
+    const result = transformSummonContext(context);
+    expect(result).toBe(context);
+  });
+
+  it("preserves newlines in context text", () => {
+    const context = "Line 1: budget rules\nLine 2: safety rules";
+    const result = transformSummonContext(context);
+    expect(result).toBe(context);
+  });
+
+  it("truncates via JS string slice (UTF-16 code units)", () => {
+    // Emoji like U+1F4B0 takes 2 UTF-16 code units (surrogate pair)
+    // 498 ASCII + 1 emoji (2 units) = 500 code units
+    const context = "a".repeat(498) + "\u{1F4B0}\u{1F6A8}";
+    expect(context.length).toBe(502); // 498 + 2 + 2
+    const result = transformSummonContext(context);
+    // slice(0, 500) keeps first 500 code units: 498 'a's + first emoji
+    expect(result).toHaveLength(500);
+    expect(result).toBe("a".repeat(498) + "\u{1F4B0}");
+  });
+});
+
+/**
+ * Mirrors the shell escaping used in setup page for OpenClaw commands.
+ * Tests that summonContext is safe for shell interpolation.
+ */
+function shellEscape(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+describe("shellEscape — summonContext safety", () => {
+  it("wraps simple text in single quotes", () => {
+    expect(shellEscape("hello world")).toBe("'hello world'");
+  });
+
+  it("escapes single quotes", () => {
+    expect(shellEscape("don't stop")).toBe("'don'\\''t stop'");
+  });
+
+  it("prevents command injection via $() syntax", () => {
+    const malicious = "$(rm -rf /)";
+    const escaped = shellEscape(malicious);
+    expect(escaped).toBe("'$(rm -rf /)'");
+    // Inside single quotes, $() is literal, not expanded
+    expect(escaped).not.toContain("\\$");
+  });
+
+  it("prevents backtick injection", () => {
+    const malicious = "`whoami`";
+    const escaped = shellEscape(malicious);
+    expect(escaped).toBe("'`whoami`'");
+  });
+
+  it("handles empty string", () => {
+    expect(shellEscape("")).toBe("''");
+  });
+
+  it("handles string with only single quotes", () => {
+    // Input: '''  (3 single quotes)
+    // Each ' becomes '\'' in the replace, then wrapped in outer quotes
+    const result = shellEscape("'''");
+    // Verify structure: starts and ends with quote, contains escaped sequences
+    expect(result).toMatch(/^'/);
+    expect(result).toMatch(/'$/);
+    expect(result).toContain("\\");
+    // Verify the exact length: ' + ('\'' * 3) + ' = 1 + 12 + 1 = 14
+    expect(result).toHaveLength(14);
+  });
+});

--- a/src/__tests__/validations/summon-context.test.ts
+++ b/src/__tests__/validations/summon-context.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { providerUpdateSchema } from "@/lib/validations";
+
+describe("providerUpdateSchema — summonContext", () => {
+  it("accepts a valid summonContext string", () => {
+    const result = providerUpdateSchema.safeParse({
+      summonContext: "Only summon me when you have tried at least 3 different approaches.",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.summonContext).toBe(
+        "Only summon me when you have tried at least 3 different approaches."
+      );
+    }
+  });
+
+  it("accepts summonContext at exactly 500 characters", () => {
+    const context = "a".repeat(500);
+    const result = providerUpdateSchema.safeParse({ summonContext: context });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.summonContext).toBe(context);
+    }
+  });
+
+  it("rejects summonContext exceeding 500 characters", () => {
+    const context = "a".repeat(501);
+    const result = providerUpdateSchema.safeParse({ summonContext: context });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues[0];
+      expect(issue.path).toEqual(["summonContext"]);
+      expect(issue.code).toBe("too_big");
+    }
+  });
+
+  it("accepts null summonContext", () => {
+    const result = providerUpdateSchema.safeParse({ summonContext: null });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.summonContext).toBeNull();
+    }
+  });
+
+  it("accepts undefined summonContext (field omitted)", () => {
+    const result = providerUpdateSchema.safeParse({ isActive: true });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.summonContext).toBeUndefined();
+    }
+  });
+
+  it("accepts empty object without summonContext", () => {
+    const result = providerUpdateSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.summonContext).toBeUndefined();
+    }
+  });
+
+  it("accepts empty string (API layer converts to null)", () => {
+    const result = providerUpdateSchema.safeParse({ summonContext: "" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Zod passes empty string; the API PATCH handler converts "" to null
+      expect(result.data.summonContext).toBe("");
+    }
+  });
+
+  it("rejects non-string types", () => {
+    const result = providerUpdateSchema.safeParse({ summonContext: 42 });
+    expect(result.success).toBe(false);
+  });
+
+  it("preserves special characters in summonContext", () => {
+    const context = `Summon me before any $100+ action. Use "caution" with 'quotes' & <tags>.`;
+    const result = providerUpdateSchema.safeParse({ summonContext: context });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.summonContext).toBe(context);
+    }
+  });
+
+  it("preserves unicode characters", () => {
+    const context = "Rufe mich nur bei kritischen Entscheidungen an. Kosten uber 100EUR.";
+    const result = providerUpdateSchema.safeParse({ summonContext: context });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.summonContext).toBe(context);
+    }
+  });
+
+  it("coexists with other provider fields", () => {
+    const result = providerUpdateSchema.safeParse({
+      name: "Test Provider",
+      isActive: true,
+      tagline: "Expert helper",
+      summonContext: "Safety-first: always summon before irreversible actions.",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("Test Provider");
+      expect(result.data.summonContext).toBe(
+        "Safety-first: always summon before irreversible actions."
+      );
+    }
+  });
+});

--- a/src/app/api/providers/[id]/route.ts
+++ b/src/app/api/providers/[id]/route.ts
@@ -27,6 +27,7 @@ export async function GET(
       digestTime: true,
       tagline: true,
       taglineEnabled: true,
+      summonContext: true,
       userId: true,
     },
   });
@@ -72,6 +73,9 @@ export async function PATCH(
   if (body.availableDays !== undefined) data.availableDays = body.availableDays;
   if (body.digestTime !== undefined) data.digestTime = body.digestTime;
 
+  // Summoning context
+  if (body.summonContext !== undefined) data.summonContext = (body.summonContext as string)?.slice(0, 500) || null;
+
   // Phone-first
   if (body.phoneFirst !== undefined) data.phoneFirst = body.phoneFirst;
   if (body.phoneFirstIntegrationId !== undefined) data.phoneFirstIntegrationId = body.phoneFirstIntegrationId;
@@ -91,6 +95,7 @@ export async function PATCH(
       digestTime: true,
       tagline: true,
       taglineEnabled: true,
+      summonContext: true,
     },
   });
 

--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -23,6 +23,7 @@ export async function GET() {
       phoneFirst: true,
       phoneFirstIntegrationId: true,
       phoneFirstTimeout: true,
+      summonContext: true,
       _count: { select: { apiKeys: true } },
       ipEvents: { orderBy: { lastSeen: "desc" } },
       channelProviders: {

--- a/src/app/api/v1/providers/route.ts
+++ b/src/app/api/v1/providers/route.ts
@@ -27,6 +27,7 @@ export async function GET(request: Request) {
           id: key.provider.id,
           name: key.provider.name,
           isActive: key.provider.isActive,
+          summonContext: key.provider.summonContext ?? null,
         },
       ],
     });

--- a/src/app/api/v1/setup-link/route.ts
+++ b/src/app/api/v1/setup-link/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
 
   const apiKey = await prisma.apiKey.findFirst({
     where: { id: keyId, provider: { userId: user.id } },
-    select: { id: true, provider: { select: { name: true } } },
+    select: { id: true, provider: { select: { name: true, summonContext: true } } },
   });
 
   if (!apiKey) {
@@ -56,6 +56,7 @@ export async function POST(request: NextRequest) {
       channel,
       subChannel: subChannel ?? null,
       providerName: apiKey.provider?.name ?? null,
+      summonContext: apiKey.provider?.summonContext ?? null,
       timeout: timeout ?? 900,
       pollInterval: pollInterval ?? 3,
       globalInstall: globalInstall ?? true,

--- a/src/app/setup/[token]/page.tsx
+++ b/src/app/setup/[token]/page.tsx
@@ -25,15 +25,20 @@ function buildInstallCommand(opts: {
   pollInterval: number;
   globalInstall: boolean;
   providerName: string;
+  summonContext?: string | null;
 }): string {
-  const { channel, skillDir, baseUrl, apiKey, timeout, pollInterval, globalInstall, providerName } = opts;
+  const { channel, skillDir, baseUrl, apiKey, timeout, pollInterval, globalInstall, providerName, summonContext } = opts;
   const safeName = shellEscape(providerName);
 
   if (channel === "openclaw") {
-    return `cd ~/clawd && HEYSUMMON_BASE_URL="${baseUrl}" bash skills/heysummon/scripts/add-provider.sh ${apiKey} ${safeName}`;
+    const envPrefix = summonContext
+      ? `HEYSUMMON_BASE_URL="${baseUrl}" HEYSUMMON_SUMMON_CONTEXT=${shellEscape(summonContext)} `
+      : `HEYSUMMON_BASE_URL="${baseUrl}" `;
+    return `cd ~/clawd && ${envPrefix}bash skills/heysummon/scripts/add-provider.sh ${apiKey} ${safeName}`;
   }
 
   const npmFlag = globalInstall ? " -g" : "";
+  const contextLine = summonContext ? `\nHEYSUMMON_SUMMON_CONTEXT=${summonContext}` : "";
   return `npm install${npmFlag} @heysummon/consumer-sdk && \\
 mkdir -p ${skillDir}/scripts && \\
 for f in ask.sh sdk.sh setup.sh add-provider.sh list-providers.sh check-status.sh; do \\
@@ -46,7 +51,7 @@ cat > ${skillDir}/.env << 'EOF'
 HEYSUMMON_BASE_URL=${baseUrl}
 HEYSUMMON_API_KEY=${apiKey}
 HEYSUMMON_TIMEOUT=${timeout}
-HEYSUMMON_POLL_INTERVAL=${pollInterval}
+HEYSUMMON_POLL_INTERVAL=${pollInterval}${contextLine}
 EOF
 echo "HeySummon skill installed successfully."`;
 }
@@ -88,6 +93,7 @@ export default async function SetupPage({
     pollInterval: record.pollInterval,
     globalInstall: record.globalInstall,
     providerName,
+    summonContext: record.summonContext,
   });
 
   return (
@@ -167,6 +173,24 @@ export default async function SetupPage({
                 Credentials are pre-filled. The command downloads the skill scripts and configures the connection.
               </p>
             </section>
+
+            {/* Summoning guidelines (if set) */}
+            {record.summonContext && (
+              <section>
+                <h2 className="mb-3 text-lg font-semibold text-white">
+                  Summoning guidelines
+                </h2>
+                <div className="rounded-lg border border-amber-800/50 bg-amber-950/20 p-4">
+                  <p className="text-sm text-amber-200 whitespace-pre-wrap">
+                    {record.summonContext}
+                  </p>
+                </div>
+                <p className="mt-3 text-xs text-zinc-600">
+                  These guidelines are embedded in the skill configuration and will be available to
+                  the AI agent at runtime.
+                </p>
+              </section>
+            )}
 
             {/* Verify */}
             <section>

--- a/src/components/dashboard/provider-detail-panel.tsx
+++ b/src/components/dashboard/provider-detail-panel.tsx
@@ -114,6 +114,7 @@ interface Provider {
   phoneFirst: boolean;
   phoneFirstIntegrationId: string | null;
   phoneFirstTimeout: number;
+  summonContext: string | null;
   ipEvents: IpEvent[];
   channelProviders: ChannelProvider[];
   _count: { apiKeys: number };
@@ -215,6 +216,12 @@ export function ProviderDetailPanel({
   const [phoneSaved, setPhoneSaved] = useState(false);
   const [phoneError, setPhoneError] = useState<string | null>(null);
 
+  // Summon context
+  const [summonContext, setSummonContext] = useState("");
+  const [summonContextEditing, setSummonContextEditing] = useState(false);
+  const [savingSummonContext, setSavingSummonContext] = useState(false);
+  const [summonContextSaved, setSummonContextSaved] = useState(false);
+
   // General
   const [copied, setCopied] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -242,6 +249,7 @@ export function ProviderDetailPanel({
       setPhoneFirst(found.phoneFirst || false);
       setPhoneIntegrationId(found.phoneFirstIntegrationId || null);
       setPhoneTimeout(found.phoneFirstTimeout || 30);
+      setSummonContext(found.summonContext || "");
     }
 
     // Load voice integrations
@@ -381,6 +389,21 @@ export function ProviderDetailPanel({
     setSavingPhone(false);
     setPhoneSaved(true);
     setTimeout(() => setPhoneSaved(false), 2000);
+    fetchProvider();
+    onUpdated();
+  };
+
+  const saveSummonContext = async () => {
+    setSavingSummonContext(true);
+    await fetch(`/api/providers/${providerId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ summonContext: summonContext.trim() || null }),
+    });
+    setSavingSummonContext(false);
+    setSummonContextSaved(true);
+    setSummonContextEditing(false);
+    setTimeout(() => setSummonContextSaved(false), 2000);
     fetchProvider();
     onUpdated();
   };
@@ -667,6 +690,75 @@ export function ProviderDetailPanel({
               )}
 
               {phoneError && <p className="text-sm text-red-500">{phoneError}</p>}
+            </div>
+          )}
+        </div>
+
+        {/* ── Summoning context ──────────────────────────────── */}
+        <div className="pt-8 mt-8 border-t border-border">
+          <div className="flex items-center gap-2 mb-4">
+            <h3 className="font-serif text-base font-semibold text-foreground">Summoning context</h3>
+            {savingSummonContext && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
+            {summonContextSaved && <Check className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />}
+          </div>
+          <p className="text-sm text-muted-foreground mb-4">
+            Tell consumer AI agents when they should and shouldn&apos;t summon you. This text is included in the skill configuration.
+          </p>
+
+          {!summonContextEditing && !summonContext ? (
+            <Button variant="outline" size="sm" onClick={() => setSummonContextEditing(true)}>
+              Add guidelines
+            </Button>
+          ) : !summonContextEditing && summonContext ? (
+            <div>
+              <div className="rounded-md border border-amber-200 dark:border-amber-900/40 bg-amber-50/50 dark:bg-amber-950/10 p-3 mb-3">
+                <p className="text-sm text-foreground whitespace-pre-wrap">{summonContext}</p>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => setSummonContextEditing(true)}>
+                Edit
+              </Button>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div className="flex flex-wrap gap-1.5">
+                {[
+                  { label: "Strict", text: "Only summon when the AI is completely stuck and cannot proceed without human input. Do not summon for style preferences or minor decisions." },
+                  { label: "Budget-conscious", text: "Summon only for decisions that could cost money or affect billing. Proceed autonomously on all other tasks." },
+                  { label: "Safety-first", text: "Summon before any destructive action (deleting data, modifying production, changing permissions). Proceed autonomously for read-only and development tasks." },
+                ].map((preset) => (
+                  <button
+                    key={preset.label}
+                    type="button"
+                    onClick={() => setSummonContext(preset.text)}
+                    className={`rounded-md border px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                      summonContext === preset.text
+                        ? "border-primary bg-primary/5 text-primary dark:bg-primary/10"
+                        : "border-border text-muted-foreground hover:border-primary/40 hover:text-foreground"
+                    }`}
+                  >
+                    {preset.label}
+                  </button>
+                ))}
+              </div>
+              <textarea
+                value={summonContext}
+                onChange={(e) => setSummonContext(e.target.value.slice(0, 500))}
+                placeholder="e.g. Only summon me when you need architecture decisions or production access..."
+                rows={3}
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-ring resize-none"
+              />
+              <div className="flex items-center justify-between">
+                <p className="text-[11px] text-muted-foreground">{summonContext.length}/500</p>
+                <div className="flex items-center gap-2">
+                  <Button variant="ghost" size="sm" onClick={() => { setSummonContextEditing(false); setSummonContext(provider?.summonContext || ""); }}>
+                    Cancel
+                  </Button>
+                  <Button size="sm" onClick={saveSummonContext} disabled={savingSummonContext}>
+                    {savingSummonContext ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}
+                    Save
+                  </Button>
+                </div>
+              </div>
             </div>
           )}
         </div>

--- a/src/components/onboarding/step-client.tsx
+++ b/src/components/onboarding/step-client.tsx
@@ -20,6 +20,21 @@ const TIMEOUT_PRESETS = [
   { value: -1, label: "Custom", desc: "" },
 ];
 
+const SUMMON_CONTEXT_PRESETS = [
+  {
+    label: "Strict",
+    text: "Only summon when the AI is completely stuck and cannot proceed without human input. Do not summon for style preferences or minor decisions.",
+  },
+  {
+    label: "Budget-conscious",
+    text: "Summon only for decisions that could cost money or affect billing. Proceed autonomously on all other tasks.",
+  },
+  {
+    label: "Safety-first",
+    text: "Summon before any destructive action (deleting data, modifying production, changing permissions). Proceed autonomously for read-only and development tasks.",
+  },
+];
+
 const PLATFORM_META: Record<string, { label: string; skillDir: string }> = {
   openclaw: { label: "OpenClaw", skillDir: "skills/heysummon" },
   claudecode: { label: "Claude Code", skillDir: ".claude/skills/heysummon" },
@@ -58,6 +73,7 @@ export function StepClient({
   const [customTimeout, setCustomTimeout] = useState<number | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [showExamples, setShowExamples] = useState(false);
+  const [summonContext, setSummonContext] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   // Created client data
@@ -121,6 +137,15 @@ export function StepClient({
       setKeyId(createdKeyId);
       setApiKey(createdApiKey);
 
+      // Save summoning context to provider profile (if set)
+      if (summonContext.trim()) {
+        await fetch(`/api/providers/${providerId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ summonContext: summonContext.trim() }),
+        });
+      }
+
       // Generate setup link
       const linkRes = await fetch("/api/v1/setup-link", {
         method: "POST",
@@ -168,7 +193,7 @@ cat > ${skillDir}/.env << 'EOF'
 HEYSUMMON_BASE_URL=${baseUrl}
 HEYSUMMON_API_KEY=${apiKey}
 HEYSUMMON_TIMEOUT=${timeout}
-HEYSUMMON_POLL_INTERVAL=${pollInterval}
+HEYSUMMON_POLL_INTERVAL=${pollInterval}${summonContext.trim() ? `\nHEYSUMMON_SUMMON_CONTEXT=${summonContext.trim()}` : ""}
 EOF
 echo "Verifying connection..." && \\
 curl -sf "${baseUrl}/api/v1/whoami" \\
@@ -345,6 +370,43 @@ B) Create a /discounts endpoint myself`}</pre>
             )}
           </div>
 
+          {/* Summoning context */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Summoning guidelines (optional)
+            </label>
+            <p className="mb-2 text-[11px] text-muted-foreground">
+              Tell the AI when it should and shouldn&apos;t summon you. This context
+              is included in the consumer&apos;s environment.
+            </p>
+            <div className="mb-2 flex flex-wrap gap-1.5">
+              {SUMMON_CONTEXT_PRESETS.map((preset) => (
+                <button
+                  key={preset.label}
+                  type="button"
+                  onClick={() => setSummonContext(preset.text)}
+                  className={`rounded-md border px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                    summonContext === preset.text
+                      ? "border-primary bg-primary/5 text-primary dark:bg-primary/10"
+                      : "border-border text-muted-foreground hover:border-primary/40 hover:text-foreground"
+                  }`}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+            <textarea
+              value={summonContext}
+              onChange={(e) => setSummonContext(e.target.value.slice(0, 500))}
+              placeholder="e.g. Only summon me when you need architecture decisions or production access..."
+              rows={3}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-ring resize-none"
+            />
+            <p className="mt-1 text-right text-[11px] text-muted-foreground">
+              {summonContext.length}/500
+            </p>
+          </div>
+
           {/* Advanced settings — poll interval */}
           <div>
             <button
@@ -417,6 +479,16 @@ B) Create a /discounts endpoint myself`}</pre>
       {/* Phase: Connecting */}
       {phase === "connecting" && (
         <div className="space-y-4 animate-in fade-in duration-200">
+          {summonContext.trim() && (
+            <div className="rounded-md border border-amber-200 dark:border-amber-900/40 bg-amber-50/50 dark:bg-amber-950/10 p-3">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400 mb-1">
+                Summoning guidelines
+              </p>
+              <p className="text-xs text-foreground whitespace-pre-wrap">
+                {summonContext.trim()}
+              </p>
+            </div>
+          )}
           {isSkillBased ? (
             <div className="rounded-lg border border-border bg-black p-4">
               <p className="mb-2 text-xs text-muted-foreground font-medium">

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -77,6 +77,7 @@ export const providerUpdateSchema = z.object({
   phoneFirst: z.boolean().optional(),
   phoneFirstIntegrationId: z.string().nullable().optional(),
   phoneFirstTimeout: z.number().int().min(10).max(120).optional(),
+  summonContext: z.string().max(500).nullable().optional(),
 });
 
 // ── Key schemas ──

--- a/website/pages/provider/dashboard.mdx
+++ b/website/pages/provider/dashboard.mdx
@@ -38,6 +38,7 @@ The **Users** page lets you manage provider profiles. Each user can have:
 - A provider key (`hs_prov_*`)
 - IP bindings — visible inline with Allow/Blacklist/Remove actions
 - An active/inactive status
+- **Summoning context** — optional guidelines (up to 500 characters) that tell AI agents when they should and shouldn't summon this provider. Choose from presets (Strict, Budget-conscious, Safety-first) or write custom instructions. This text is embedded in the consumer's skill configuration as `HEYSUMMON_SUMMON_CONTEXT`.
 
 ---
 

--- a/website/pages/reference/api.mdx
+++ b/website/pages/reference/api.mdx
@@ -214,6 +214,29 @@ Availability is configured per provider profile in the dashboard:
 
 ---
 
+## Summoning context
+
+Providers can set optional advisory text (`summonContext`) that tells AI agents when
+to summon them. This is stored on the provider profile (max 500 characters) and flows
+through the system:
+
+1. Provider writes context via the dashboard or wizard
+2. Saved to `UserProfile.summonContext` via `PATCH /api/providers/:id`
+3. Copied to `SetupToken.summonContext` when a setup link is created
+4. Embedded as `HEYSUMMON_SUMMON_CONTEXT` in the consumer's `.env`
+5. Referenced by the skill's "When to summon" section at runtime
+
+| Field | Type | Max | Description |
+|-------|------|-----|-------------|
+| `summonContext` | string \| null | 500 | Advisory guidelines for AI on when to summon this provider |
+
+The field is available on:
+- `PATCH /api/providers/:id` (set/update)
+- `GET /api/providers/:id` (read)
+- `GET /api/v1/providers` (consumer-facing, read)
+
+---
+
 ## Webhooks
 
 HeySummon can send webhook notifications to external endpoints when events occur.

--- a/website/pages/reference/changelog.mdx
+++ b/website/pages/reference/changelog.mdx
@@ -2,6 +2,18 @@ import { Callout } from 'nextra/components'
 
 # Changelog
 
+## Summoning Context -- 2026-03-30
+
+### Added
+- **Summoning context**: Providers can now set advisory guidelines (up to 500 characters) that tell AI agents when to summon them. Choose from presets (Strict, Budget-conscious, Safety-first) or write custom instructions.
+- Summoning context is configurable in the onboarding wizard and the dashboard provider detail panel.
+- Context flows through to the consumer's skill configuration as `HEYSUMMON_SUMMON_CONTEXT` environment variable.
+- Both consumer and OpenClaw SKILL.md files include a new "When to summon" section that references the context.
+- `GET /api/v1/providers` now includes `summonContext` in the response.
+- Setup page shows summoning guidelines when configured.
+
+---
+
 ## Docker Refactor — 2026-03-27
 
 ### Changed


### PR DESCRIPTION
Adds a summoning context field (max 500 chars) to provider profiles, allowing providers to define when AI agents should and should not summon them. Context flows from provider through setup tokens into the consumer skill configuration. Includes 3 presets (Strict, Budget-conscious, Safety-first) in both wizard and dashboard editors. Full documentation updates across API reference, dashboard docs, changelog, and both SKILL.md files.
