### PR TITLE
feat: add n8n-nodes-heysummon community node + integrations IA (HEY-239)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -7,6 +7,7 @@ Portions of this software are licensed as follows:
   To use source code files that contain ".cloud." in their filename or ".cloud" in their dirname you must hold a
   valid HeySummon Cloud License specifically allowing you access to such source code files and as defined
   in "LICENSE_CLOUD.md".
+- The `packages/n8n-nodes-heysummon/` package is licensed under the MIT License (see `packages/n8n-nodes-heysummon/LICENSE`) so it can ship as an n8n Verified Community Node; it is NOT covered by the Sustainable Use License below.
 - All third party components incorporated into the HeySummon Software are licensed under the original license
   provided by the owner of the applicable component.
 - Content outside of the above mentioned files or restrictions is available under the "Sustainable Use

--- a/landingspage/public/llms.txt
+++ b/landingspage/public/llms.txt
@@ -1,0 +1,69 @@
+# HeySummon
+
+> HeySummon is the open-source, self-hosted, platform-agnostic human-in-the-loop (HITL) platform for AI agents. When an AI agent gets stuck, needs approval, or lacks context, it sends an encrypted help request to a human expert who responds through the dashboard, Telegram, Slack, or another channel. The agent picks up the response and continues its workflow.
+
+HeySummon works with any AI agent that can make HTTP requests -- Claude Code, Codex, Gemini, OpenClaw, LangChain, n8n, or custom agents. Experts respond through a web dashboard, Telegram, Slack, or other supported channels. All communication is end-to-end encrypted using X25519 key exchange and AES-256-GCM.
+
+The platform is self-hosted: run it on your infrastructure with `npx @heysummon/app`, Docker Compose, or from source. Your data never leaves your servers.
+
+## Docs
+
+- [Getting Started / Quickstart](https://docs.heysummon.ai/getting-started/quickstart): Install and run HeySummon in under 5 minutes using NPX, Docker, or from source
+- [How It Works](https://docs.heysummon.ai/getting-started/how-it-works): The full request lifecycle from agent question to expert answer
+- [Concepts](https://docs.heysummon.ai/getting-started/concepts): Key terminology -- Consumer, Expert, HelpRequest, Channel, Guard
+- [Best Practices](https://docs.heysummon.ai/best-practices): Guidelines for when and how agents should summon human help
+
+## Consumer (AI Agent) Integration
+
+- [Consumer Overview](https://docs.heysummon.ai/consumer/overview): How AI agents connect to and use HeySummon
+- [Consumer API Reference](https://docs.heysummon.ai/consumer/api-reference): HTTP API endpoints for submitting and polling help requests
+- [Real-time Events](https://docs.heysummon.ai/consumer/realtime): Polling and real-time event handling for agent integrations
+- [Consumer Encryption](https://docs.heysummon.ai/consumer/encryption): End-to-end encryption implementation for consumer requests
+
+## Client Platform Guides
+
+- [Claude Code](https://docs.heysummon.ai/clients/claude-code): Set up HeySummon as a skill in Claude Code
+- [Codex CLI](https://docs.heysummon.ai/clients/codex): Integrate with OpenAI Codex CLI
+- [Gemini CLI](https://docs.heysummon.ai/clients/gemini): Integrate with Google Gemini CLI
+- [OpenClaw](https://docs.heysummon.ai/clients/openclaw): Integrate with OpenClaw agents
+
+## Orchestrator Integrations
+
+- [n8n](https://docs.heysummon.ai/integrations/orchestrators/n8n): Add a human-in-the-loop step to any n8n workflow with the n8n-nodes-heysummon community node
+
+## Expert (Human) Dashboard
+
+- [Expert Overview](https://docs.heysummon.ai/expert/overview): The expert role and how to get started responding to agent requests
+- [Dashboard Guide](https://docs.heysummon.ai/expert/dashboard): Using the web dashboard to review and respond to help requests
+- [Conversations](https://docs.heysummon.ai/expert/conversations): Managing multi-turn conversations with agents
+- [API Keys](https://docs.heysummon.ai/expert/api-keys): Creating and managing API keys for agent authentication
+
+## Security
+
+- [Security Overview](https://docs.heysummon.ai/security/overview): Security architecture including Guard proxy, E2E encryption, and defense layers
+- [API Security](https://docs.heysummon.ai/security/api-security): API authentication, rate limiting, and access control
+- [Encryption](https://docs.heysummon.ai/security/encryption): X25519 key exchange and AES-256-GCM encryption details
+- [Content Safety](https://docs.heysummon.ai/security/content-safety-guard): Content safety middleware, XSS prevention, and PII filtering
+
+## Self-Hosting
+
+- [Self-Hosting Overview](https://docs.heysummon.ai/self-hosting/overview): Deployment options -- NPX, Docker Compose, or from source
+- [Docker Setup](https://docs.heysummon.ai/self-hosting/docker): Docker Compose deployment with Caddy, Cloudflare, or Tailscale
+- [NPX Installer](https://docs.heysummon.ai/self-hosting/npx): One-command install with npx @heysummon/app
+- [Environment Variables](https://docs.heysummon.ai/self-hosting/environment-variables): All configuration options and environment variables
+- [Architecture](https://docs.heysummon.ai/self-hosting/architecture): System architecture diagram and component overview
+- [Database](https://docs.heysummon.ai/self-hosting/database): SQLite and PostgreSQL setup
+
+## Reference
+
+- [Full API Reference](https://docs.heysummon.ai/reference/api): Complete API endpoint documentation with request/response examples
+- [Message Flow](https://docs.heysummon.ai/reference/message-flow): Detailed encrypted message flow diagrams
+- [Changelog](https://docs.heysummon.ai/reference/changelog): Release notes and version history
+
+## Optional
+
+Other integrations -- including orchestrators -- live in the dedicated section above.
+
+- [Contributing](https://docs.heysummon.ai/contributing): How to contribute to HeySummon
+- [Twilio Voice Integration](https://docs.heysummon.ai/integrations/twilio): Set up voice-based expert responses via Twilio
+- [Source Code](https://github.com/thomasansems/heysummon): GitHub repository

--- a/packages/consumer-sdk/__tests__/client.test.ts
+++ b/packages/consumer-sdk/__tests__/client.test.ts
@@ -201,6 +201,57 @@ describe("HeySummonClient", () => {
     await trailingClient.whoami();
     expect(called).toBe(true);
   });
+
+  it("attaches userAgent and extraHeaders to outgoing requests", async () => {
+    let receivedUA: string | null = null;
+    let receivedExtra: string | null = null;
+    let receivedKey: string | null = null;
+    server.use(
+      http.get(`${BASE}/api/v1/whoami`, ({ request }) => {
+        receivedUA = request.headers.get("user-agent");
+        receivedExtra = request.headers.get("x-trace-id");
+        receivedKey = request.headers.get("x-api-key");
+        return HttpResponse.json({
+          keyId: "kid1",
+          keyName: null,
+          expert: { id: "e1", name: "P", isActive: true },
+        });
+      })
+    );
+
+    const taggedClient = new HeySummonClient({
+      baseUrl: BASE,
+      apiKey: API_KEY,
+      userAgent: "my-orchestrator/9.9.9 (test)",
+      extraHeaders: { "x-trace-id": "trace-xyz" },
+    });
+    await taggedClient.whoami();
+    expect(receivedUA).toBe("my-orchestrator/9.9.9 (test)");
+    expect(receivedExtra).toBe("trace-xyz");
+    expect(receivedKey).toBe(API_KEY);
+  });
+
+  it("does not let extraHeaders override x-api-key", async () => {
+    let receivedKey: string | null = null;
+    server.use(
+      http.get(`${BASE}/api/v1/whoami`, ({ request }) => {
+        receivedKey = request.headers.get("x-api-key");
+        return HttpResponse.json({
+          keyId: "kid1",
+          keyName: null,
+          expert: { id: "e1", name: "P", isActive: true },
+        });
+      })
+    );
+
+    const c = new HeySummonClient({
+      baseUrl: BASE,
+      apiKey: API_KEY,
+      extraHeaders: { "x-api-key": "stolen-key" },
+    });
+    await c.whoami();
+    expect(receivedKey).toBe(API_KEY);
+  });
 });
 
 /* -------------------------------------------------------------------------- */

--- a/packages/consumer-sdk/src/client.ts
+++ b/packages/consumer-sdk/src/client.ts
@@ -44,6 +44,8 @@ export class HeySummonClient {
   private readonly baseUrl: string;
   private readonly apiKey: string;
   private readonly e2e: boolean;
+  private readonly userAgent?: string;
+  private readonly extraHeaders?: Record<string, string>;
   private readonly keyStore: Map<string, KeyMaterial> = new Map();
   private readonly providerKeyCache: Map<string, { encPub: string; signPub: string }> = new Map();
 
@@ -51,6 +53,8 @@ export class HeySummonClient {
     this.baseUrl = opts.baseUrl.replace(/\/$/, ""); // trim trailing slash
     this.apiKey = opts.apiKey;
     this.e2e = opts.e2e !== false; // default true
+    this.userAgent = opts.userAgent;
+    this.extraHeaders = opts.extraHeaders;
   }
 
   private async request<T>(
@@ -58,12 +62,23 @@ export class HeySummonClient {
     path: string,
     body?: unknown
   ): Promise<T> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (this.extraHeaders) {
+      for (const [k, v] of Object.entries(this.extraHeaders)) {
+        headers[k] = v;
+      }
+    }
+    if (this.userAgent) {
+      headers["User-Agent"] = this.userAgent;
+    }
+    // x-api-key is set last so callers cannot override authentication via extraHeaders.
+    headers["x-api-key"] = this.apiKey;
+
     const res = await fetch(`${this.baseUrl}${path}`, {
       method,
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": this.apiKey,
-      },
+      headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,
     });
 

--- a/packages/consumer-sdk/src/types.ts
+++ b/packages/consumer-sdk/src/types.ts
@@ -81,6 +81,13 @@ export interface HeySummonClientOptions {
   apiKey: string;
   /** Enable E2E encryption (default: true). Set to false for plaintext mode. */
   e2e?: boolean;
+  /** Override the outgoing User-Agent header on every request. */
+  userAgent?: string;
+  /**
+   * Additional headers attached to every request. Cannot override
+   * `x-api-key`; can be overridden by `userAgent` for the User-Agent slot.
+   */
+  extraHeaders?: Record<string, string>;
 }
 
 export interface DecryptedMessage {

--- a/packages/n8n-nodes-heysummon/.gitignore
+++ b/packages/n8n-nodes-heysummon/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.tsbuildinfo

--- a/packages/n8n-nodes-heysummon/LICENSE
+++ b/packages/n8n-nodes-heysummon/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thomas Ansems and HeySummon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/n8n-nodes-heysummon/README.md
+++ b/packages/n8n-nodes-heysummon/README.md
@@ -44,7 +44,6 @@ Blocks the workflow and waits for a human expert to answer.
 | Context | no | — | Optional background sent as the first message. |
 | Expert Name | no | — | Route to a specific expert. |
 | Requires Approval | no | `false` | Surface an Approve/Deny prompt. |
-| Summoning Guidelines | no | — | Per-call override of the `HEYSUMMON_SUMMON_CONTEXT` rules. |
 | Timeout (ms) | yes | `900000` | Local timeout (default 15 min). |
 | Poll Interval (ms) | yes | `2000` | How often to poll for the answer. |
 

--- a/packages/n8n-nodes-heysummon/README.md
+++ b/packages/n8n-nodes-heysummon/README.md
@@ -1,0 +1,115 @@
+# n8n-nodes-heysummon
+
+[![n8n.io - Workflow Automation](https://img.shields.io/badge/n8n.io-community-FF6D5A.svg)](https://n8n.io)
+
+`n8n-nodes-heysummon` is the community node for [HeySummon](https://heysummon.ai) — the open-source human-in-the-loop platform for AI agents. Drop a HeySummon node into any n8n workflow to pause execution, summon a human expert, and resume on the answer.
+
+This package is **MIT licensed** so it qualifies for n8n's Verified Community Nodes program. The rest of the HeySummon repo remains under the Sustainable Use License.
+
+## Installation (self-hosted n8n)
+
+In your n8n instance:
+
+1. Go to **Settings → Community Nodes**.
+2. Click **Install** and enter `n8n-nodes-heysummon`.
+3. Restart n8n if prompted.
+
+Or install manually inside your n8n container:
+
+```bash
+npm install n8n-nodes-heysummon
+```
+
+## Configure the credential
+
+Create a new credential of type **HeySummon API**:
+
+| Field | Value |
+| --- | --- |
+| API Key | `hs_cli_…` from your HeySummon dashboard |
+| Base URL | The URL of your self-hosted HeySummon instance (e.g. `https://heysummon.example.com`) |
+| End-to-End Encryption | On by default. Leave on for the security default. |
+
+Click **Test** — n8n will hit `GET /api/v1/health` on your instance. A green tick means you're ready.
+
+## Operations
+
+### Summon
+
+Blocks the workflow and waits for a human expert to answer.
+
+| Parameter | Required | Default | Description |
+| --- | --- | --- | --- |
+| Question | yes | — | Plaintext question for the expert. |
+| Context | no | — | Optional background sent as the first message. |
+| Expert Name | no | — | Route to a specific expert. |
+| Requires Approval | no | `false` | Surface an Approve/Deny prompt. |
+| Summoning Guidelines | no | — | Per-call override of the `HEYSUMMON_SUMMON_CONTEXT` rules. |
+| Timeout (ms) | yes | `900000` | Local timeout (default 15 min). |
+| Poll Interval (ms) | yes | `2000` | How often to poll for the answer. |
+
+Returns:
+
+```json
+{
+  "requestId": "cm…",
+  "refCode": "HS-A1B2C3D4",
+  "status": "responded",
+  "response": "Plaintext answer (decrypted in process when E2E is on).",
+  "responder": "expert-name-or-null",
+  "respondedAt": "2026-04-20T18:30:00.000Z",
+  "latencyMs": 87412,
+  "messageCount": 3
+}
+```
+
+### Get Status
+
+Single non-blocking poll for an existing request.
+
+| Parameter | Required | Default | Description |
+| --- | --- | --- | --- |
+| Request ID | yes | — | The `requestId` returned by a previous Summon call. |
+
+When E2E is on (the default), `response` is always `null` — the per-execution decryption keypair from the original Summon is no longer in memory. To get the decrypted response across executions, disable E2E on the credential.
+
+## Errors
+
+Both operations return a structured error envelope on failure:
+
+```json
+{
+  "error": {
+    "kind": "timeout | expired | network | http | guard_rejected | validation",
+    "message": "Human readable explanation",
+    "requestId": "cm… or null",
+    "refCode": "HS-… or null",
+    "httpStatus": 504,
+    "retriable": false
+  }
+}
+```
+
+When **Continue On Fail** is enabled on the node, errors are emitted on the second output port instead of throwing.
+
+## User-Agent attribution
+
+Every outbound call from this node sets:
+
+```
+User-Agent: n8n-nodes-heysummon/<package-version> (n8n; node)
+```
+
+The version is read from this package's `package.json` at runtime. HeySummon uses this signal to attribute n8n install volume — please leave the User-Agent intact.
+
+## Self-hosted only
+
+HeySummon is currently self-hosted only. The Base URL on the credential must point at your own instance — there is no managed cloud endpoint to leave the field blank for.
+
+## Documentation
+
+Full documentation: [docs.heysummon.ai/integrations/orchestrators/n8n](https://docs.heysummon.ai/integrations/orchestrators/n8n).
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/packages/n8n-nodes-heysummon/package.json
+++ b/packages/n8n-nodes-heysummon/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "n8n-nodes-heysummon",
+  "version": "0.1.0",
+  "description": "n8n community node for HeySummon — pause workflows for human-in-the-loop input from a self-hosted HeySummon instance.",
+  "license": "MIT",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc && node scripts/copy-assets.mjs",
+    "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [
+    "n8n",
+    "n8n-community-node-package",
+    "hitl",
+    "human-in-the-loop",
+    "heysummon"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "n8n": {
+    "n8nNodesApiVersion": 1,
+    "credentials": [
+      "dist/credentials/HeySummonApi.credentials.js"
+    ],
+    "nodes": [
+      "dist/nodes/HeySummon/HeySummon.node.js"
+    ]
+  },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "dependencies": {
+    "@heysummon/consumer-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "n8n-workflow": "^1.0.0",
+    "typescript": "^5",
+    "vitest": "^4.0.18"
+  },
+  "peerDependencies": {
+    "n8n-workflow": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thomasansems/heysummon.git",
+    "directory": "packages/n8n-nodes-heysummon"
+  }
+}

--- a/packages/n8n-nodes-heysummon/package.json
+++ b/packages/n8n-nodes-heysummon/package.json
@@ -22,6 +22,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "n8n": {
     "n8nNodesApiVersion": 1,
     "credentials": [

--- a/packages/n8n-nodes-heysummon/scripts/copy-assets.mjs
+++ b/packages/n8n-nodes-heysummon/scripts/copy-assets.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { mkdirSync, copyFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = dirname(here);
+
+const assets = [
+  ["src/nodes/HeySummon/heysummon.svg", "dist/nodes/HeySummon/heysummon.svg"],
+];
+
+for (const [from, to] of assets) {
+  const src = join(root, from);
+  const dest = join(root, to);
+  mkdirSync(dirname(dest), { recursive: true });
+  copyFileSync(src, dest);
+  process.stdout.write(`copied ${from} -> ${to}\n`);
+}

--- a/packages/n8n-nodes-heysummon/src/__tests__/continue-on-fail.test.ts
+++ b/packages/n8n-nodes-heysummon/src/__tests__/continue-on-fail.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { HeySummon } from "../nodes/HeySummon/HeySummon.node";
+import { installFetchMock, type MockFetchHandle } from "./test-utils";
+
+let handle: MockFetchHandle | null = null;
+afterEach(() => {
+  handle?.restore();
+  handle = null;
+});
+
+interface ParamMap {
+  operation: string;
+  question?: string;
+  context?: string;
+  expertName?: string;
+  requiresApproval?: boolean;
+  summoningGuidelines?: string;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  requestId?: string;
+}
+
+function makeExecuteContext(opts: {
+  params: ParamMap;
+  continueOnFail: boolean;
+}) {
+  return {
+    getInputData: () => [{ json: {} }],
+    getCredentials: async () => ({
+      apiKey: "hs_cli_test",
+      baseUrl: "http://hs.test",
+      e2eEnabled: true,
+    }),
+    getNodeParameter: (name: string, _index: number, fallback?: unknown) => {
+      const value = (opts.params as unknown as Record<string, unknown>)[name];
+      return value !== undefined ? value : fallback;
+    },
+    continueOnFail: () => opts.continueOnFail,
+    getNode: () => ({ name: "HeySummon", type: "heySummon" }),
+  };
+}
+
+describe("HeySummon node — Continue On Fail (T6)", () => {
+  it("emits errors on the second output port when continueOnFail is true", async () => {
+    handle = installFetchMock([
+      {
+        method: "POST",
+        matcher: "/api/v1/help",
+        handler: () => ({
+          status: 400,
+          body: {
+            reason: "guard_blocked",
+            message: "blocked by guard",
+          },
+        }),
+      },
+    ]);
+
+    const ctx = makeExecuteContext({
+      params: { operation: "summon", question: "ping", timeoutMs: 1_000, pollIntervalMs: 5 },
+      continueOnFail: true,
+    });
+
+    const node = new HeySummon();
+    const result = await node.execute.call(
+      ctx as unknown as Parameters<typeof node.execute>[0] extends never
+        ? never
+        : unknown as never
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toHaveLength(0);
+    expect(result[1]).toHaveLength(1);
+    const errJson = result[1][0].json as { error: { kind: string } };
+    expect(errJson.error.kind).toBe("guard_rejected");
+  });
+
+  it("throws NodeOperationError when continueOnFail is false", async () => {
+    handle = installFetchMock([
+      {
+        method: "POST",
+        matcher: "/api/v1/help",
+        handler: () => ({
+          status: 400,
+          body: { reason: "guard_blocked", message: "blocked" },
+        }),
+      },
+    ]);
+
+    const ctx = makeExecuteContext({
+      params: { operation: "summon", question: "ping", timeoutMs: 1_000, pollIntervalMs: 5 },
+      continueOnFail: false,
+    });
+
+    const node = new HeySummon();
+    await expect(
+      node.execute.call(
+        ctx as unknown as Parameters<typeof node.execute>[0] extends never
+          ? never
+          : unknown as never
+      )
+    ).rejects.toThrow(/blocked/);
+  });
+});

--- a/packages/n8n-nodes-heysummon/src/__tests__/continue-on-fail.test.ts
+++ b/packages/n8n-nodes-heysummon/src/__tests__/continue-on-fail.test.ts
@@ -15,7 +15,6 @@ interface ParamMap {
   context?: string;
   expertName?: string;
   requiresApproval?: boolean;
-  summoningGuidelines?: string;
   timeoutMs?: number;
   pollIntervalMs?: number;
   requestId?: string;

--- a/packages/n8n-nodes-heysummon/src/__tests__/get-status.test.ts
+++ b/packages/n8n-nodes-heysummon/src/__tests__/get-status.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { runGetStatus } from "../nodes/HeySummon/operations/getStatus";
+import { installFetchMock, type MockFetchHandle } from "./test-utils";
+
+let handle: MockFetchHandle | null = null;
+afterEach(() => {
+  handle?.restore();
+  handle = null;
+});
+
+describe("Get Status — happy path, E2E on (T7)", () => {
+  it("returns metadata with response: null when E2E is on", async () => {
+    handle = installFetchMock([
+      {
+        method: "GET",
+        matcher: /\/api\/v1\/help\/req-7$/,
+        handler: () => ({
+          status: 200,
+          body: {
+            requestId: "req-7",
+            refCode: "HS-7",
+            status: "responded",
+            response: "leaked plaintext from server",
+            expert: { id: "e1", name: "Thomas" },
+          },
+        }),
+      },
+    ]);
+
+    const result = await runGetStatus(
+      { requestId: "req-7" },
+      { apiKey: "k", baseUrl: "http://hs.test", e2eEnabled: true }
+    );
+
+    if ("error" in result) throw new Error("expected success");
+    expect(result.requestId).toBe("req-7");
+    expect(result.status).toBe("responded");
+    expect(result.responder).toBe("Thomas");
+    expect(result.response).toBeNull();
+  });
+
+  it("returns the plaintext response when E2E is off", async () => {
+    handle = installFetchMock([
+      {
+        method: "GET",
+        matcher: /\/api\/v1\/help\/req-8$/,
+        handler: () => ({
+          status: 200,
+          body: {
+            requestId: "req-8",
+            refCode: "HS-8",
+            status: "responded",
+            response: "Yes, do it",
+          },
+        }),
+      },
+    ]);
+
+    const result = await runGetStatus(
+      { requestId: "req-8" },
+      { apiKey: "k", baseUrl: "http://hs.test", e2eEnabled: false }
+    );
+
+    if ("error" in result) throw new Error("expected success");
+    expect(result.response).toBe("Yes, do it");
+  });
+});
+
+describe("Get Status — invalid requestId (T8)", () => {
+  it("returns kind=http with httpStatus=404", async () => {
+    handle = installFetchMock([
+      {
+        method: "GET",
+        matcher: /\/api\/v1\/help\/missing$/,
+        handler: () => ({
+          status: 404,
+          body: { error: "Not found" },
+        }),
+      },
+    ]);
+
+    const result = await runGetStatus(
+      { requestId: "missing" },
+      { apiKey: "k", baseUrl: "http://hs.test", e2eEnabled: true }
+    );
+    if (!("error" in result)) throw new Error("expected error envelope");
+    expect(result.error.kind).toBe("http");
+    expect(result.error.httpStatus).toBe(404);
+    expect(result.error.retriable).toBe(false);
+  });
+
+  it("returns kind=validation when requestId is empty", async () => {
+    const result = await runGetStatus(
+      { requestId: "" },
+      { apiKey: "k", baseUrl: "http://hs.test", e2eEnabled: true }
+    );
+    if (!("error" in result)) throw new Error("expected error envelope");
+    expect(result.error.kind).toBe("validation");
+  });
+});

--- a/packages/n8n-nodes-heysummon/src/__tests__/summon.test.ts
+++ b/packages/n8n-nodes-heysummon/src/__tests__/summon.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { runSummon } from "../nodes/HeySummon/operations/summon";
+import { installFetchMock, type MockFetchHandle } from "./test-utils";
+
+const credentials = {
+  apiKey: "hs_cli_test",
+  baseUrl: "http://hs.test",
+  e2eEnabled: true,
+};
+
+let handle: MockFetchHandle | null = null;
+afterEach(() => {
+  handle?.restore();
+  handle = null;
+});
+
+describe("Summon — happy path (T1)", () => {
+  it("submits, polls, and returns a success envelope on responded", async () => {
+    let pollCount = 0;
+    handle = installFetchMock([
+      {
+        method: "POST",
+        matcher: "/api/v1/help",
+        handler: ({ body }) => {
+          const b = body as Record<string, unknown>;
+          expect(typeof b.signPublicKey).toBe("string");
+          expect(typeof b.encryptPublicKey).toBe("string");
+          return {
+            status: 200,
+            body: {
+              requestId: "req-happy",
+              refCode: "HS-HAPPY",
+              status: "pending",
+              expiresAt: new Date(Date.now() + 60_000).toISOString(),
+            },
+          };
+        },
+      },
+      {
+        method: "GET",
+        matcher: /\/api\/v1\/help\/req-happy$/,
+        handler: () => {
+          pollCount++;
+          if (pollCount < 2) {
+            return {
+              status: 200,
+              body: {
+                requestId: "req-happy",
+                refCode: "HS-HAPPY",
+                status: "pending",
+              },
+            };
+          }
+          return {
+            status: 200,
+            body: {
+              requestId: "req-happy",
+              refCode: "HS-HAPPY",
+              status: "responded",
+              response: "Yes, ship it",
+              expert: { id: "e1", name: "Thomas" },
+            },
+          };
+        },
+      },
+    ]);
+
+    const result = await runSummon(
+      {
+        question: "Should I deploy?",
+        timeoutMs: 10_000,
+        pollIntervalMs: 5,
+      },
+      credentials,
+      { sleep: () => Promise.resolve() }
+    );
+
+    if ("error" in result) {
+      throw new Error(`expected success, got ${JSON.stringify(result)}`);
+    }
+    expect(result.status).toBe("responded");
+    expect(result.requestId).toBe("req-happy");
+    expect(result.refCode).toBe("HS-HAPPY");
+    expect(result.response).toBe("Yes, ship it");
+    expect(result.responder).toBe("Thomas");
+  });
+});
+
+describe("Summon — server-side expired (T2)", () => {
+  it("returns kind=expired and stops polling", async () => {
+    handle = installFetchMock([
+      {
+        method: "POST",
+        matcher: "/api/v1/help",
+        handler: () => ({
+          status: 200,
+          body: {
+            requestId: "req-exp",
+            refCode: "HS-EXP",
+            status: "pending",
+            expiresAt: new Date().toISOString(),
+          },
+        }),
+      },
+      {
+        method: "GET",
+        matcher: /\/api\/v1\/help\/req-exp$/,
+        handler: () => ({
+          status: 200,
+          body: { requestId: "req-exp", refCode: "HS-EXP", status: "expired" },
+        }),
+      },
+    ]);
+
+    const result = await runSummon(
+      { question: "ping", timeoutMs: 5_000, pollIntervalMs: 5 },
+      credentials,
+      { sleep: () => Promise.resolve() }
+    );
+
+    if (!("error" in result)) {
+      throw new Error("expected error envelope");
+    }
+    expect(result.error.kind).toBe("expired");
+    expect(result.error.retriable).toBe(false);
+    expect(result.error.requestId).toBe("req-exp");
+  });
+});
+
+describe("Summon — local timeout (T3)", () => {
+  it("returns kind=timeout when deadline elapses", async () => {
+    let pollCalls = 0;
+    handle = installFetchMock([
+      {
+        method: "POST",
+        matcher: "/api/v1/help",
+        handler: () => ({
+          status: 200,
+          body: {
+            requestId: "req-to",
+            refCode: null,
+            status: "pending",
+            expiresAt: new Date().toISOString(),
+          },
+        }),
+      },
+      {
+        method: "GET",
+        matcher: /\/api\/v1\/help\/req-to$/,
+        handler: () => {
+          pollCalls++;
+          return {
+            status: 200,
+            body: { requestId: "req-to", refCode: null, status: "pending" },
+          };
+        },
+      },
+      {
+        method: "POST",
+        matcher: /\/api\/v1\/help\/req-to\/timeout$/,
+        handler: () => ({ status: 200, body: { ok: true } }),
+      },
+    ]);
+
+    let t = 1_000;
+    const result = await runSummon(
+      { question: "slow", timeoutMs: 50, pollIntervalMs: 10 },
+      credentials,
+      {
+        sleep: () => Promise.resolve(),
+        now: () => {
+          t += 30;
+          return t;
+        },
+      }
+    );
+
+    if (!("error" in result)) {
+      throw new Error("expected error envelope");
+    }
+    expect(result.error.kind).toBe("timeout");
+    expect(result.error.retriable).toBe(true);
+    expect(pollCalls).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("Summon — network error on submit (T4)", () => {
+  it("returns kind=network and retriable=true", async () => {
+    handle = installFetchMock([
+      {
+        method: "POST",
+        matcher: "/api/v1/help",
+        handler: () => {
+          throw new TypeError("ECONNREFUSED");
+        },
+      },
+    ]);
+
+    const result = await runSummon(
+      { question: "ping", timeoutMs: 1_000, pollIntervalMs: 5 },
+      credentials,
+      { sleep: () => Promise.resolve() }
+    );
+
+    if (!("error" in result)) {
+      throw new Error("expected error envelope");
+    }
+    expect(result.error.kind).toBe("network");
+    expect(result.error.retriable).toBe(true);
+  });
+});
+
+describe("Summon — Guard rejection on POST /help (T5)", () => {
+  it("returns kind=guard_rejected with the Guard message", async () => {
+    handle = installFetchMock([
+      {
+        method: "POST",
+        matcher: "/api/v1/help",
+        handler: () => ({
+          status: 400,
+          body: {
+            error: "guard_rejected",
+            reason: "guard_blocked_pii",
+            message: "Question contains PII the Guard refuses to forward.",
+          },
+        }),
+      },
+    ]);
+
+    const result = await runSummon(
+      { question: "leak my SSN", timeoutMs: 1_000, pollIntervalMs: 5 },
+      credentials,
+      { sleep: () => Promise.resolve() }
+    );
+
+    if (!("error" in result)) {
+      throw new Error("expected error envelope");
+    }
+    expect(result.error.kind).toBe("guard_rejected");
+    expect(result.error.message).toContain("PII");
+    expect(result.error.httpStatus).toBe(400);
+  });
+});

--- a/packages/n8n-nodes-heysummon/src/__tests__/test-utils.ts
+++ b/packages/n8n-nodes-heysummon/src/__tests__/test-utils.ts
@@ -1,0 +1,83 @@
+import { vi } from "vitest";
+
+export interface RouteHandler {
+  (init: { method: string; headers: Headers; body?: unknown }): Promise<{
+    status: number;
+    body: unknown;
+  }> | { status: number; body: unknown };
+}
+
+export interface CapturedCall {
+  url: string;
+  method: string;
+  headers: Headers;
+  body: unknown;
+}
+
+export interface MockFetchHandle {
+  calls: CapturedCall[];
+  restore(): void;
+}
+
+/**
+ * Install a global fetch mock that routes URL+method matches to handlers.
+ * Returns a handle holding all captured calls and a restore() helper.
+ */
+export function installFetchMock(
+  routes: Array<{
+    method?: string;
+    matcher: string | RegExp;
+    handler: RouteHandler;
+  }>
+): MockFetchHandle {
+  const original = globalThis.fetch;
+  const calls: CapturedCall[] = [];
+
+  const fakeFetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : (input as { url: string }).url;
+    const method = (init?.method ?? "GET").toUpperCase();
+    const headers = new Headers(init?.headers as HeadersInit | undefined);
+    const bodyText = init?.body ? init.body.toString() : undefined;
+    let parsedBody: unknown = undefined;
+    if (bodyText) {
+      try {
+        parsedBody = JSON.parse(bodyText);
+      } catch {
+        parsedBody = bodyText;
+      }
+    }
+    calls.push({ url, method, headers, body: parsedBody });
+
+    const route = routes.find((r) => {
+      const methodOk = !r.method || r.method.toUpperCase() === method;
+      const urlOk =
+        typeof r.matcher === "string" ? url.endsWith(r.matcher) : r.matcher.test(url);
+      return methodOk && urlOk;
+    });
+
+    if (!route) {
+      throw new Error(`No mock route for ${method} ${url}`);
+    }
+
+    const result = await route.handler({ method, headers, body: parsedBody });
+    return new Response(JSON.stringify(result.body), {
+      status: result.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  // @ts-expect-error overriding global for test
+  globalThis.fetch = fakeFetch;
+  return {
+    calls,
+    restore() {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+export function networkError(message = "ECONNREFUSED"): RouteHandler {
+  return () => {
+    throw new TypeError(message);
+  };
+}

--- a/packages/n8n-nodes-heysummon/src/__tests__/user-agent.test.ts
+++ b/packages/n8n-nodes-heysummon/src/__tests__/user-agent.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { runSummon } from "../nodes/HeySummon/operations/summon";
+import { runGetStatus } from "../nodes/HeySummon/operations/getStatus";
+import { _resetUserAgentCache, getUserAgent } from "../nodes/HeySummon/lib/user-agent";
+import { installFetchMock, type MockFetchHandle } from "./test-utils";
+
+const credentials = {
+  apiKey: "hs_cli_test",
+  baseUrl: "http://hs.test",
+  e2eEnabled: true,
+};
+
+let pkgVersion: string;
+
+beforeEach(() => {
+  _resetUserAgentCache();
+  const pkg = JSON.parse(
+    readFileSync(join(__dirname, "..", "..", "package.json"), "utf8")
+  ) as { version: string };
+  pkgVersion = pkg.version;
+});
+
+let handle: MockFetchHandle | null = null;
+afterEach(() => {
+  handle?.restore();
+  handle = null;
+});
+
+describe("User-Agent attribution (T9)", () => {
+  it("sets the User-Agent header on POST /help and GET /help/:id during Summon", async () => {
+    handle = installFetchMock([
+      {
+        method: "POST",
+        matcher: "/api/v1/help",
+        handler: () => ({
+          status: 200,
+          body: {
+            requestId: "req-1",
+            refCode: "HS-UA",
+            status: "pending",
+            expiresAt: new Date().toISOString(),
+          },
+        }),
+      },
+      {
+        method: "GET",
+        matcher: /\/api\/v1\/help\/req-1$/,
+        handler: () => ({
+          status: 200,
+          body: {
+            requestId: "req-1",
+            refCode: "HS-UA",
+            status: "responded",
+            response: "OK",
+          },
+        }),
+      },
+    ]);
+
+    const result = await runSummon(
+      { question: "ping", timeoutMs: 5_000, pollIntervalMs: 10 },
+      credentials,
+      { sleep: () => Promise.resolve() }
+    );
+
+    expect("error" in result).toBe(false);
+    expect(handle.calls.length).toBeGreaterThanOrEqual(2);
+    const expectedUA = `n8n-nodes-heysummon/${pkgVersion} (n8n; node)`;
+    expect(getUserAgent()).toBe(expectedUA);
+    for (const call of handle.calls) {
+      expect(call.headers.get("user-agent")).toBe(expectedUA);
+    }
+  });
+
+  it("sets the User-Agent header on GET /help/:id during Get Status", async () => {
+    handle = installFetchMock([
+      {
+        method: "GET",
+        matcher: /\/api\/v1\/help\/req-2$/,
+        handler: () => ({
+          status: 200,
+          body: {
+            requestId: "req-2",
+            refCode: "HS-UA",
+            status: "pending",
+          },
+        }),
+      },
+    ]);
+
+    await runGetStatus({ requestId: "req-2" }, credentials);
+    const expectedUA = `n8n-nodes-heysummon/${pkgVersion} (n8n; node)`;
+    expect(handle.calls[0].headers.get("user-agent")).toBe(expectedUA);
+  });
+});

--- a/packages/n8n-nodes-heysummon/src/credentials/HeySummonApi.credentials.ts
+++ b/packages/n8n-nodes-heysummon/src/credentials/HeySummonApi.credentials.ts
@@ -1,0 +1,49 @@
+import type {
+  ICredentialTestRequest,
+  ICredentialType,
+  INodeProperties,
+} from "n8n-workflow";
+
+export class HeySummonApi implements ICredentialType {
+  name = "heySummonApi";
+  displayName = "HeySummon API";
+  documentationUrl = "https://docs.heysummon.ai/integrations/orchestrators/n8n";
+
+  properties: INodeProperties[] = [
+    {
+      displayName: "API Key",
+      name: "apiKey",
+      type: "string",
+      typeOptions: { password: true },
+      default: "",
+      required: true,
+      description: "HeySummon client API key (`hs_cli_*`).",
+    },
+    {
+      displayName: "Base URL",
+      name: "baseUrl",
+      type: "string",
+      default: "http://localhost:3445",
+      required: true,
+      placeholder: "https://heysummon.example.com",
+      description:
+        "URL of your self-hosted HeySummon instance. Must include the scheme (http/https).",
+    },
+    {
+      displayName: "End-to-End Encryption",
+      name: "e2eEnabled",
+      type: "boolean",
+      default: true,
+      description:
+        "When on (default), the node generates ephemeral X25519 keys per Summon and decrypts the response in process. When off, Get Status can return the plaintext response across executions.",
+    },
+  ];
+
+  test: ICredentialTestRequest = {
+    request: {
+      baseURL: "={{$credentials.baseUrl}}",
+      url: "/api/v1/health",
+      method: "GET",
+    },
+  };
+}

--- a/packages/n8n-nodes-heysummon/src/index.ts
+++ b/packages/n8n-nodes-heysummon/src/index.ts
@@ -1,0 +1,2 @@
+export { HeySummon } from "./nodes/HeySummon/HeySummon.node";
+export { HeySummonApi } from "./credentials/HeySummonApi.credentials";

--- a/packages/n8n-nodes-heysummon/src/nodes/HeySummon/HeySummon.node.ts
+++ b/packages/n8n-nodes-heysummon/src/nodes/HeySummon/HeySummon.node.ts
@@ -87,16 +87,6 @@ export class HeySummon implements INodeType {
         description: "Surface the request as an Approve/Deny prompt in the dashboard.",
       },
       {
-        displayName: "Summoning Guidelines",
-        name: "summoningGuidelines",
-        type: "string",
-        typeOptions: { rows: 3 },
-        default: "",
-        displayOptions: { show: { operation: ["summon"] } },
-        description:
-          "Per-call override of the HEYSUMMON_SUMMON_CONTEXT rules.",
-      },
-      {
         displayName: "Timeout (Ms)",
         name: "timeoutMs",
         type: "number",
@@ -158,11 +148,6 @@ export class HeySummon implements INodeType {
               i,
               false
             ) as boolean,
-            summoningGuidelines: this.getNodeParameter(
-              "summoningGuidelines",
-              i,
-              ""
-            ) as string,
             timeoutMs: this.getNodeParameter("timeoutMs", i, 900_000) as number,
             pollIntervalMs: this.getNodeParameter(
               "pollIntervalMs",

--- a/packages/n8n-nodes-heysummon/src/nodes/HeySummon/HeySummon.node.ts
+++ b/packages/n8n-nodes-heysummon/src/nodes/HeySummon/HeySummon.node.ts
@@ -1,0 +1,217 @@
+import {
+  NodeConnectionTypes,
+  NodeOperationError,
+  type IDataObject,
+  type IExecuteFunctions,
+  type INodeExecutionData,
+  type INodeType,
+  type INodeTypeDescription,
+} from "n8n-workflow";
+
+import { runSummon } from "./operations/summon";
+import { runGetStatus } from "./operations/getStatus";
+import type { CredentialFields } from "./lib/client-factory";
+
+export class HeySummon implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: "HeySummon",
+    name: "heySummon",
+    icon: "file:heysummon.svg",
+    group: ["transform"],
+    version: 1,
+    subtitle: "={{$parameter[\"operation\"]}}",
+    description: "Human-in-the-loop for AI agents",
+    defaults: { name: "HeySummon" },
+    inputs: [NodeConnectionTypes.Main],
+    outputs: [NodeConnectionTypes.Main],
+    credentials: [{ name: "heySummonApi", required: true }],
+    properties: [
+      {
+        displayName: "Operation",
+        name: "operation",
+        type: "options",
+        noDataExpression: true,
+        default: "summon",
+        options: [
+          {
+            name: "Summon",
+            value: "summon",
+            description:
+              "Send a question to a human expert and wait for the answer.",
+            action: "Summon a human expert",
+          },
+          {
+            name: "Get Status",
+            value: "getStatus",
+            description:
+              "Look up an existing request by ID. Returns metadata only when E2E is on.",
+            action: "Get the status of an existing help request",
+          },
+        ],
+      },
+
+      // Summon parameters
+      {
+        displayName: "Question",
+        name: "question",
+        type: "string",
+        typeOptions: { rows: 4 },
+        default: "",
+        required: true,
+        displayOptions: { show: { operation: ["summon"] } },
+        description: "Plaintext question for the expert.",
+      },
+      {
+        displayName: "Context",
+        name: "context",
+        type: "string",
+        typeOptions: { rows: 4 },
+        default: "",
+        displayOptions: { show: { operation: ["summon"] } },
+        description: "Optional background sent as the first message.",
+      },
+      {
+        displayName: "Expert Name",
+        name: "expertName",
+        type: "string",
+        default: "",
+        displayOptions: { show: { operation: ["summon"] } },
+        description: "Route to a specific expert by name. Leave blank for default routing.",
+      },
+      {
+        displayName: "Requires Approval",
+        name: "requiresApproval",
+        type: "boolean",
+        default: false,
+        displayOptions: { show: { operation: ["summon"] } },
+        description: "Surface the request as an Approve/Deny prompt in the dashboard.",
+      },
+      {
+        displayName: "Summoning Guidelines",
+        name: "summoningGuidelines",
+        type: "string",
+        typeOptions: { rows: 3 },
+        default: "",
+        displayOptions: { show: { operation: ["summon"] } },
+        description:
+          "Per-call override of the HEYSUMMON_SUMMON_CONTEXT rules.",
+      },
+      {
+        displayName: "Timeout (Ms)",
+        name: "timeoutMs",
+        type: "number",
+        default: 900000,
+        typeOptions: { minValue: 1000 },
+        displayOptions: { show: { operation: ["summon"] } },
+        description: "Client-side timeout in milliseconds (default 15 minutes).",
+      },
+      {
+        displayName: "Poll Interval (Ms)",
+        name: "pollIntervalMs",
+        type: "number",
+        default: 2000,
+        typeOptions: { minValue: 250 },
+        displayOptions: { show: { operation: ["summon"] } },
+        description: "How often to poll the status endpoint while waiting.",
+      },
+
+      // Get Status parameters
+      {
+        displayName: "Request ID",
+        name: "requestId",
+        type: "string",
+        default: "",
+        required: true,
+        displayOptions: { show: { operation: ["getStatus"] } },
+        description: "The requestId returned by a previous Summon call.",
+      },
+    ],
+  };
+
+  async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+    const items = this.getInputData();
+    const successItems: INodeExecutionData[] = [];
+    const failureItems: INodeExecutionData[] = [];
+
+    const credentialsRaw = (await this.getCredentials("heySummonApi")) as Record<
+      string,
+      unknown
+    >;
+    const credentials: CredentialFields = {
+      apiKey: String(credentialsRaw.apiKey ?? ""),
+      baseUrl: String(credentialsRaw.baseUrl ?? ""),
+      e2eEnabled: credentialsRaw.e2eEnabled !== false,
+    };
+
+    for (let i = 0; i < items.length; i++) {
+      const operation = this.getNodeParameter("operation", i) as string;
+      let result: unknown;
+
+      if (operation === "summon") {
+        result = await runSummon(
+          {
+            question: this.getNodeParameter("question", i, "") as string,
+            context: this.getNodeParameter("context", i, "") as string,
+            expertName: this.getNodeParameter("expertName", i, "") as string,
+            requiresApproval: this.getNodeParameter(
+              "requiresApproval",
+              i,
+              false
+            ) as boolean,
+            summoningGuidelines: this.getNodeParameter(
+              "summoningGuidelines",
+              i,
+              ""
+            ) as string,
+            timeoutMs: this.getNodeParameter("timeoutMs", i, 900_000) as number,
+            pollIntervalMs: this.getNodeParameter(
+              "pollIntervalMs",
+              i,
+              2_000
+            ) as number,
+          },
+          credentials
+        );
+      } else if (operation === "getStatus") {
+        result = await runGetStatus(
+          {
+            requestId: this.getNodeParameter("requestId", i, "") as string,
+          },
+          credentials
+        );
+      } else {
+        throw new NodeOperationError(
+          this.getNode(),
+          `Unknown operation: ${operation}`,
+          { itemIndex: i }
+        );
+      }
+
+      const isErrorEnvelope =
+        typeof result === "object" &&
+        result !== null &&
+        "error" in (result as Record<string, unknown>);
+
+      if (isErrorEnvelope) {
+        if (this.continueOnFail()) {
+          failureItems.push({ json: result as IDataObject, pairedItem: i });
+        } else {
+          const env = (result as { error: { message: string } }).error;
+          throw new NodeOperationError(this.getNode(), env.message, {
+            itemIndex: i,
+          });
+        }
+      } else {
+        successItems.push({
+          json: result as IDataObject,
+          pairedItem: i,
+        });
+      }
+    }
+
+    if (failureItems.length > 0) {
+      return [successItems, failureItems];
+    }
+    return [successItems];
+  }
+}

--- a/packages/n8n-nodes-heysummon/src/nodes/HeySummon/heysummon.svg
+++ b/packages/n8n-nodes-heysummon/src/nodes/HeySummon/heysummon.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#0F172A"/>
+  <path d="M20 22h24M20 32h24M20 42h16" stroke="#22D3EE" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="48" cy="42" r="4" fill="#22D3EE"/>
+</svg>

--- a/packages/n8n-nodes-heysummon/src/nodes/HeySummon/lib/client-factory.ts
+++ b/packages/n8n-nodes-heysummon/src/nodes/HeySummon/lib/client-factory.ts
@@ -1,0 +1,22 @@
+import { HeySummonClient } from "@heysummon/consumer-sdk";
+import { getUserAgent } from "./user-agent";
+
+export interface CredentialFields {
+  apiKey: string;
+  baseUrl: string;
+  e2eEnabled?: boolean;
+}
+
+/**
+ * Build a HeySummonClient that always tags outbound calls with the n8n
+ * User-Agent (PRD §4.8). E2E follows the credential default (true unless
+ * explicitly disabled).
+ */
+export function buildClient(creds: CredentialFields): HeySummonClient {
+  return new HeySummonClient({
+    apiKey: creds.apiKey,
+    baseUrl: creds.baseUrl,
+    e2e: creds.e2eEnabled !== false,
+    userAgent: getUserAgent(),
+  });
+}

--- a/packages/n8n-nodes-heysummon/src/nodes/HeySummon/lib/errors.ts
+++ b/packages/n8n-nodes-heysummon/src/nodes/HeySummon/lib/errors.ts
@@ -1,0 +1,51 @@
+export type ErrorKind =
+  | "timeout"
+  | "expired"
+  | "network"
+  | "http"
+  | "guard_rejected"
+  | "validation";
+
+export interface ErrorEnvelope {
+  error: {
+    kind: ErrorKind;
+    message: string;
+    requestId: string | null;
+    refCode: string | null;
+    httpStatus?: number;
+    retriable: boolean;
+  };
+}
+
+const RETRIABLE_KINDS: ReadonlySet<ErrorKind> = new Set<ErrorKind>([
+  "timeout",
+  "network",
+]);
+
+export function buildError(opts: {
+  kind: ErrorKind;
+  message: string;
+  requestId?: string | null;
+  refCode?: string | null;
+  httpStatus?: number;
+  retriable?: boolean;
+}): ErrorEnvelope {
+  const retriable =
+    opts.retriable !== undefined
+      ? opts.retriable
+      : opts.kind === "http" && (opts.httpStatus ?? 0) >= 500
+        ? true
+        : RETRIABLE_KINDS.has(opts.kind);
+
+  const env: ErrorEnvelope["error"] = {
+    kind: opts.kind,
+    message: opts.message,
+    requestId: opts.requestId ?? null,
+    refCode: opts.refCode ?? null,
+    retriable,
+  };
+  if (opts.httpStatus !== undefined) {
+    env.httpStatus = opts.httpStatus;
+  }
+  return { error: env };
+}

--- a/packages/n8n-nodes-heysummon/src/nodes/HeySummon/lib/schemas.ts
+++ b/packages/n8n-nodes-heysummon/src/nodes/HeySummon/lib/schemas.ts
@@ -3,7 +3,6 @@ export interface SummonInput {
   context?: string;
   expertName?: string;
   requiresApproval?: boolean;
-  summoningGuidelines?: string;
   timeoutMs: number;
   pollIntervalMs: number;
 }
@@ -59,8 +58,6 @@ export function validateSummon(raw: Partial<SummonInput>): {
       context: raw.context?.toString().trim() || undefined,
       expertName: raw.expertName?.toString().trim() || undefined,
       requiresApproval: !!raw.requiresApproval,
-      summoningGuidelines:
-        raw.summoningGuidelines?.toString().trim() || undefined,
       timeoutMs,
       pollIntervalMs,
     },

--- a/packages/n8n-nodes-heysummon/src/nodes/HeySummon/lib/schemas.ts
+++ b/packages/n8n-nodes-heysummon/src/nodes/HeySummon/lib/schemas.ts
@@ -1,0 +1,85 @@
+export interface SummonInput {
+  question: string;
+  context?: string;
+  expertName?: string;
+  requiresApproval?: boolean;
+  summoningGuidelines?: string;
+  timeoutMs: number;
+  pollIntervalMs: number;
+}
+
+export interface GetStatusInput {
+  requestId: string;
+}
+
+export interface ValidationFailure {
+  field: string;
+  message: string;
+}
+
+export function validateSummon(raw: Partial<SummonInput>): {
+  ok: true;
+  value: SummonInput;
+} | {
+  ok: false;
+  failures: ValidationFailure[];
+} {
+  const failures: ValidationFailure[] = [];
+
+  const question = (raw.question ?? "").toString().trim();
+  if (!question) {
+    failures.push({ field: "question", message: "Question is required." });
+  }
+
+  const timeoutMs =
+    typeof raw.timeoutMs === "number" && raw.timeoutMs > 0
+      ? raw.timeoutMs
+      : 900_000;
+
+  const pollIntervalMs =
+    typeof raw.pollIntervalMs === "number" && raw.pollIntervalMs > 0
+      ? raw.pollIntervalMs
+      : 2_000;
+
+  if (pollIntervalMs >= timeoutMs) {
+    failures.push({
+      field: "pollIntervalMs",
+      message: "pollIntervalMs must be smaller than timeoutMs.",
+    });
+  }
+
+  if (failures.length > 0) {
+    return { ok: false, failures };
+  }
+
+  return {
+    ok: true,
+    value: {
+      question,
+      context: raw.context?.toString().trim() || undefined,
+      expertName: raw.expertName?.toString().trim() || undefined,
+      requiresApproval: !!raw.requiresApproval,
+      summoningGuidelines:
+        raw.summoningGuidelines?.toString().trim() || undefined,
+      timeoutMs,
+      pollIntervalMs,
+    },
+  };
+}
+
+export function validateGetStatus(raw: Partial<GetStatusInput>): {
+  ok: true;
+  value: GetStatusInput;
+} | {
+  ok: false;
+  failures: ValidationFailure[];
+} {
+  const requestId = (raw.requestId ?? "").toString().trim();
+  if (!requestId) {
+    return {
+      ok: false,
+      failures: [{ field: "requestId", message: "requestId is required." }],
+    };
+  }
+  return { ok: true, value: { requestId } };
+}

--- a/packages/n8n-nodes-heysummon/src/nodes/HeySummon/lib/user-agent.ts
+++ b/packages/n8n-nodes-heysummon/src/nodes/HeySummon/lib/user-agent.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
+const FALLBACK_USER_AGENT = "n8n-nodes-heysummon/unknown (n8n; node)";
+
 let cached: string | null = null;
 
-function findPackageJson(start: string): string {
+function findPackageJson(start: string): string | null {
   let dir = start;
   for (let i = 0; i < 8; i++) {
     try {
@@ -20,18 +22,29 @@ function findPackageJson(start: string): string {
     if (parent === dir) break;
     dir = parent;
   }
-  throw new Error("n8n-nodes-heysummon package.json not found from " + start);
+  return null;
 }
 
 /**
  * Build the User-Agent string for outbound HeySummon API calls from this node.
  * Version is read from the node package's own package.json at runtime per PRD §4.8.
+ * Falls back to "n8n-nodes-heysummon/unknown" if the package.json cannot be located,
+ * so a misconfigured install never crashes outbound requests.
  */
 export function getUserAgent(): string {
   if (cached) return cached;
   const pkgPath = findPackageJson(__dirname);
-  const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string };
-  cached = `n8n-nodes-heysummon/${pkg.version} (n8n; node)`;
+  if (!pkgPath) {
+    cached = FALLBACK_USER_AGENT;
+    return cached;
+  }
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string };
+    const version = pkg.version?.trim() || "unknown";
+    cached = `n8n-nodes-heysummon/${version} (n8n; node)`;
+  } catch {
+    cached = FALLBACK_USER_AGENT;
+  }
   return cached;
 }
 

--- a/packages/n8n-nodes-heysummon/src/nodes/HeySummon/lib/user-agent.ts
+++ b/packages/n8n-nodes-heysummon/src/nodes/HeySummon/lib/user-agent.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+let cached: string | null = null;
+
+function findPackageJson(start: string): string {
+  let dir = start;
+  for (let i = 0; i < 8; i++) {
+    try {
+      const candidate = join(dir, "package.json");
+      const raw = readFileSync(candidate, "utf8");
+      const parsed = JSON.parse(raw) as { name?: string };
+      if (parsed.name === "n8n-nodes-heysummon") {
+        return candidate;
+      }
+    } catch {
+      // try parent
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error("n8n-nodes-heysummon package.json not found from " + start);
+}
+
+/**
+ * Build the User-Agent string for outbound HeySummon API calls from this node.
+ * Version is read from the node package's own package.json at runtime per PRD §4.8.
+ */
+export function getUserAgent(): string {
+  if (cached) return cached;
+  const pkgPath = findPackageJson(__dirname);
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string };
+  cached = `n8n-nodes-heysummon/${pkg.version} (n8n; node)`;
+  return cached;
+}
+
+/** Test helper: drop the cached value so tests can re-resolve. */
+export function _resetUserAgentCache(): void {
+  cached = null;
+}

--- a/packages/n8n-nodes-heysummon/src/nodes/HeySummon/operations/getStatus.ts
+++ b/packages/n8n-nodes-heysummon/src/nodes/HeySummon/operations/getStatus.ts
@@ -1,0 +1,72 @@
+import { HeySummonHttpError } from "@heysummon/consumer-sdk";
+import type { CredentialFields } from "../lib/client-factory";
+import { buildClient } from "../lib/client-factory";
+import { buildError, type ErrorEnvelope } from "../lib/errors";
+import { validateGetStatus, type GetStatusInput } from "../lib/schemas";
+
+export interface GetStatusSuccess {
+  requestId: string;
+  refCode: string | null;
+  status: string;
+  responder: string | null;
+  respondedAt: string | null;
+  messageCount: number;
+  /**
+   * Always null when the credential has E2E enabled (the default) — the
+   * per-execution keypair from the original Summon is no longer in memory.
+   * See PRD §4.5.
+   */
+  response: string | null;
+}
+
+export type GetStatusResult = GetStatusSuccess | ErrorEnvelope;
+
+export async function runGetStatus(
+  rawInput: Partial<GetStatusInput>,
+  credentials: CredentialFields
+): Promise<GetStatusResult> {
+  const validated = validateGetStatus(rawInput);
+  if (!validated.ok) {
+    return buildError({
+      kind: "validation",
+      message: validated.failures.map((f) => `${f.field}: ${f.message}`).join("; "),
+      requestId: null,
+      refCode: null,
+    });
+  }
+
+  const client = buildClient(credentials);
+  let status;
+  try {
+    status = await client.getRequestStatus(validated.value.requestId);
+  } catch (err) {
+    if (err instanceof HeySummonHttpError) {
+      return buildError({
+        kind: "http",
+        message: err.message,
+        requestId: validated.value.requestId,
+        refCode: null,
+        httpStatus: err.status,
+        retriable: err.status >= 500,
+      });
+    }
+    return buildError({
+      kind: "network",
+      message: err instanceof Error ? err.message : String(err),
+      requestId: validated.value.requestId,
+      refCode: null,
+    });
+  }
+
+  const e2eOn = credentials.e2eEnabled !== false;
+
+  return {
+    requestId: status.requestId ?? validated.value.requestId,
+    refCode: status.refCode ?? null,
+    status: status.status,
+    responder: status.expert?.name ?? status.expertName ?? null,
+    respondedAt: status.status === "responded" ? new Date().toISOString() : null,
+    messageCount: status.status === "responded" ? 2 : 1,
+    response: e2eOn ? null : (status.response ?? status.lastMessage ?? null),
+  };
+}

--- a/packages/n8n-nodes-heysummon/src/nodes/HeySummon/operations/summon.ts
+++ b/packages/n8n-nodes-heysummon/src/nodes/HeySummon/operations/summon.ts
@@ -1,0 +1,222 @@
+import { HeySummonHttpError } from "@heysummon/consumer-sdk";
+import type { CredentialFields } from "../lib/client-factory";
+import { buildClient } from "../lib/client-factory";
+import { buildError, type ErrorEnvelope } from "../lib/errors";
+import { validateSummon, type SummonInput } from "../lib/schemas";
+
+export interface SummonSuccess {
+  requestId: string;
+  refCode: string | null;
+  status: "responded";
+  response: string;
+  responder: string | null;
+  respondedAt: string;
+  latencyMs: number;
+  messageCount: number;
+}
+
+export type SummonResult = SummonSuccess | ErrorEnvelope;
+
+export interface SummonDeps {
+  /** Test seam — defaults to global setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Test seam — defaults to Date.now. */
+  now?: () => number;
+}
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+function classifyHttpError(
+  err: HeySummonHttpError,
+  requestId: string | null,
+  refCode: string | null
+): ErrorEnvelope {
+  if (err.status >= 400 && err.status < 500) {
+    let kind: "http" | "guard_rejected" = "http";
+    let message = err.message;
+    try {
+      const parsed = JSON.parse(err.body) as {
+        error?: string;
+        reason?: string;
+        message?: string;
+      };
+      const reason = (parsed.reason ?? parsed.error ?? "").toString().toLowerCase();
+      if (reason.includes("guard") || reason.includes("content")) {
+        kind = "guard_rejected";
+      }
+      message = parsed.message ?? parsed.error ?? message;
+    } catch {
+      // body wasn't JSON; fall through with raw message
+    }
+    return buildError({
+      kind,
+      message,
+      requestId,
+      refCode,
+      httpStatus: err.status,
+      retriable: false,
+    });
+  }
+  return buildError({
+    kind: "http",
+    message: err.message,
+    requestId,
+    refCode,
+    httpStatus: err.status,
+    retriable: err.status >= 500,
+  });
+}
+
+function classifyUnknownError(
+  err: unknown,
+  requestId: string | null,
+  refCode: string | null
+): ErrorEnvelope {
+  if (err instanceof HeySummonHttpError) {
+    return classifyHttpError(err, requestId, refCode);
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return buildError({
+    kind: "network",
+    message,
+    requestId,
+    refCode,
+  });
+}
+
+/**
+ * Run the Summon operation: submit a help request, poll until the expert
+ * responds (or until expiry / timeout / error), and return either a success
+ * envelope or a structured error envelope.
+ */
+export async function runSummon(
+  rawInput: Partial<SummonInput>,
+  credentials: CredentialFields,
+  deps: SummonDeps = {}
+): Promise<SummonResult> {
+  const validated = validateSummon(rawInput);
+  if (!validated.ok) {
+    return buildError({
+      kind: "validation",
+      message: validated.failures.map((f) => `${f.field}: ${f.message}`).join("; "),
+      requestId: null,
+      refCode: null,
+    });
+  }
+  const input = validated.value;
+
+  const client = buildClient(credentials);
+  const sleep = deps.sleep ?? defaultSleep;
+  const now = deps.now ?? Date.now;
+
+  const startedAt = now();
+
+  let requestId: string | null = null;
+  let refCode: string | null = null;
+
+  let submit;
+  try {
+    submit = await client.submitRequest({
+      question: input.question,
+      messages: input.context
+        ? [{ role: "user", content: input.context }]
+        : undefined,
+      expertName: input.expertName,
+      requiresApproval: input.requiresApproval,
+    });
+  } catch (err) {
+    return classifyUnknownError(err, null, null);
+  }
+
+  if (submit.rejected) {
+    return buildError({
+      kind: "guard_rejected",
+      message: submit.message ?? submit.reason ?? "Request rejected by HeySummon",
+      requestId: submit.requestId ?? null,
+      refCode: submit.refCode ?? null,
+      retriable: false,
+    });
+  }
+
+  requestId = submit.requestId ?? null;
+  refCode = submit.refCode ?? null;
+
+  if (!requestId) {
+    return buildError({
+      kind: "http",
+      message: "HeySummon did not return a requestId",
+      requestId: null,
+      refCode,
+    });
+  }
+
+  const deadline = startedAt + input.timeoutMs;
+  let messageCount = 0;
+
+  while (true) {
+    let status;
+    try {
+      status = await client.getRequestStatus(requestId);
+    } catch (err) {
+      return classifyUnknownError(err, requestId, refCode);
+    }
+
+    if (status.refCode) {
+      refCode = status.refCode;
+    }
+
+    if (status.status === "responded") {
+      const response =
+        status.response ??
+        status.lastMessage ??
+        "";
+      const respondedAt = new Date().toISOString();
+      const latencyMs = now() - startedAt;
+      // Approximate message count: at least the question + the response.
+      messageCount = Math.max(messageCount, 2);
+      return {
+        requestId,
+        refCode,
+        status: "responded",
+        response,
+        responder: status.expert?.name ?? status.expertName ?? null,
+        respondedAt,
+        latencyMs,
+        messageCount,
+      };
+    }
+
+    if (status.status === "expired" || status.status === "closed") {
+      return buildError({
+        kind: "expired",
+        message: `Request ${status.status}`,
+        requestId,
+        refCode,
+        retriable: false,
+      });
+    }
+
+    if (now() >= deadline) {
+      // Best-effort timeout report; ignore failures.
+      try {
+        await client.reportTimeout(requestId);
+      } catch {
+        // swallow — primary error is the timeout
+      }
+      return buildError({
+        kind: "timeout",
+        message: `Local timeout after ${input.timeoutMs}ms`,
+        requestId,
+        refCode,
+        retriable: true,
+      });
+    }
+
+    const remaining = deadline - now();
+    const wait = Math.min(input.pollIntervalMs, Math.max(0, remaining));
+    await sleep(wait);
+  }
+}

--- a/packages/n8n-nodes-heysummon/tsconfig.json
+++ b/packages/n8n-nodes-heysummon/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "src/__tests__/**"]
+}

--- a/packages/n8n-nodes-heysummon/vitest.config.ts
+++ b/packages/n8n-nodes-heysummon/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/__tests__/**/*.test.ts"],
+    environment: "node",
+    server: {
+      sourcemapIgnoreList: () => true,
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,25 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.2)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.2)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
+  packages/n8n-nodes-heysummon:
+    dependencies:
+      '@heysummon/consumer-sdk':
+        specifier: workspace:*
+        version: link:../consumer-sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      n8n-workflow:
+        specifier: ^1.0.0
+        version: 1.120.10
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.2(@types/node@20.19.39)(jsdom@25.0.1)(msw@2.12.14(@types/node@20.19.39)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+
   vercel-waitlist:
     dependencies:
       next:
@@ -1221,6 +1240,16 @@ packages:
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
+
+  '@n8n/errors@0.5.0':
+    resolution: {integrity: sha512-0Vk1Eb3Uor+zeF/WVnuhFgJc51wEBTZNBlVQy3mvyr3sGmW86bP1jA7wmRsd0DZbswPwN0vNOl/TmkDTEopOtQ==}
+
+  '@n8n/tournament@1.0.6':
+    resolution: {integrity: sha512-UGSxYXXVuOX0yL6HTLBStKYwLIa0+JmRKiSZSCMcM2s2Wax984KWT6XIA1TR/27i7yYpDk1MY14KsTPnuEp27A==}
+    engines: {node: '>=20.15', pnpm: '>=9.5'}
+
+  '@n8n_io/riot-tmpl@4.0.1':
+    resolution: {integrity: sha512-/zdRbEfTFjsm1NqnpPQHgZTkTdbp5v3VUxGeMA9098sps8jRCTraQkc3AQstJgHUm7ylBXJcIVhnVeLUMWAfwQ==}
 
   '@napi-rs/simple-git-android-arm-eabi@0.1.22':
     resolution: {integrity: sha512-JQZdnDNm8o43A5GOzwN/0Tz3CDBQtBUNqzVwEopm32uayjdjxev1Csp1JeaqF3v9djLDIvsSE39ecsN2LhCKKQ==}
@@ -2740,12 +2769,19 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  ast-types@0.15.2:
+    resolution: {integrity: sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==}
+    engines: {node: '>=4'}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -2913,6 +2949,9 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -3069,6 +3108,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -3543,6 +3585,9 @@ packages:
       typescript:
         optional: true
 
+  eslint-config-riot@1.0.0:
+    resolution: {integrity: sha512-NB/L/1Y30qyJcG5xZxCJKW/+bqyj+llbcCwo9DEz8bESIP0SLTOQ8T1DWCCFc+wJ61AMEstj4511PSScqMMfCw==}
+
   eslint-import-resolver-node@0.3.10:
     resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
 
@@ -3637,6 +3682,11 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esprima-next@5.8.4:
+    resolution: {integrity: sha512-8nYVZ4ioIH4Msjb/XmhnBdz5WRRBaYqevKa1cv9nGJdCehMbzZCPNEEnqfLCZVetUVrUPEcb5IYyu1GG4hFqgg==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -3842,6 +3892,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  form-data@4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -4230,6 +4284,10 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -4248,6 +4306,9 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
 
   is-buffer@2.0.5:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
@@ -4322,6 +4383,10 @@ packages:
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
     engines: {node: '>= 0.4'}
 
   is-negative-zero@2.0.3:
@@ -4453,8 +4518,15 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jmespath@0.16.0:
+    resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
+    engines: {node: '>= 0.6.0'}
+
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  js-base64@3.7.2:
+    resolution: {integrity: sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -4523,9 +4595,16 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jsonrepair@3.13.2:
+    resolution: {integrity: sha512-Leuly0nbM4R+S5SVJk3VHfw1oxnlEK9KygdZvfUtEtTawNDyzB4qa1xWTmFt1aeoA7sXZkVTRuIixJ8bAvqVUg==}
+    hasBin: true
+
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
+
+  jssha@3.3.1:
+    resolution: {integrity: sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -4684,6 +4763,9 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
@@ -4725,6 +4807,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  luxon@3.4.4:
+    resolution: {integrity: sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==}
+    engines: {node: '>=12'}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -4756,6 +4842,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  md5@2.3.0:
+    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
   mdast-util-definitions@5.1.2:
     resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
@@ -5150,6 +5239,9 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  n8n-workflow@1.120.10:
+    resolution: {integrity: sha512-/fGyDBlf5gCY2+BNhdxC7RbKxkcmMBAQQacdIi9CHhJpPdgKBBAnqHbJAs4Be/015jFrVp7NhjszLs4eW2m4Tw==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -5337,6 +5429,10 @@ packages:
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
     engines: {node: '>= 0.4'}
 
   object-keys@1.1.1:
@@ -5720,6 +5816,10 @@ packages:
   reading-time@1.5.0:
     resolution: {integrity: sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==}
 
+  recast@0.22.0:
+    resolution: {integrity: sha512-5AAx+mujtXijsEavc5lWXBPQqrM4+Dl5qNH96N2aNeuJFUzpiiToKPsxQD/zAIJHspz7zz0maX0PCtCTFVlixQ==}
+    engines: {node: '>= 4'}
+
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
@@ -5901,6 +6001,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -6247,6 +6351,9 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  title-case@3.0.3:
+    resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
+
   title@3.5.3:
     resolution: {integrity: sha512-20JyowYglSEeCvZv3EZ0nZ046vLarO37prvV0mbtQV7C8DJPGgN967r8SJkqd3XK3K3lD3/Iyfp3avjfil8Q2Q==}
     hasBin: true
@@ -6288,6 +6395,11 @@ packages:
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
+
+  transliteration@2.3.5:
+    resolution: {integrity: sha512-HAGI4Lq4Q9dZ3Utu2phaWgtm3vB6PkLUFqWAScg/UW+1eZ/Tg6Exo4oC0/3VUol/w4BlefLhUUSVBr/9/ZGQOw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -6511,6 +6623,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -6772,6 +6887,14 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+
   xmlbuilder@13.0.2:
     resolution: {integrity: sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==}
     engines: {node: '>=6.0'}
@@ -6824,6 +6947,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.25.67:
+    resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -7705,6 +7831,21 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
+
+  '@n8n/errors@0.5.0':
+    dependencies:
+      callsites: 3.1.0
+
+  '@n8n/tournament@1.0.6':
+    dependencies:
+      '@n8n_io/riot-tmpl': 4.0.1
+      ast-types: 0.16.1
+      esprima-next: 5.8.4
+      recast: 0.22.0
+
+  '@n8n_io/riot-tmpl@4.0.1':
+    dependencies:
+      eslint-config-riot: 1.0.0
 
   '@napi-rs/simple-git-android-arm-eabi@0.1.22':
     optional: true
@@ -9129,9 +9270,21 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.8
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
+
+  ast-types@0.15.2:
+    dependencies:
+      tslib: 2.8.1
 
   ast-types@0.16.1:
     dependencies:
@@ -9319,6 +9472,8 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  charenc@0.0.2: {}
+
   check-error@2.1.3: {}
 
   chokidar@4.0.3:
@@ -9452,6 +9607,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypt@0.0.2: {}
 
   css.escape@1.5.1: {}
 
@@ -10028,6 +10185,8 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
+  eslint-config-riot@1.0.0: {}
+
   eslint-import-resolver-node@0.3.10:
     dependencies:
       debug: 3.2.7
@@ -10200,6 +10359,8 @@ snapshots:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
+
+  esprima-next@5.8.4: {}
 
   esprima@4.0.1: {}
 
@@ -10503,6 +10664,12 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.0:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
 
   form-data@4.0.5:
     dependencies:
@@ -10980,6 +11147,11 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -11004,6 +11176,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-buffer@1.1.6: {}
 
   is-buffer@2.0.5: {}
 
@@ -11065,6 +11239,11 @@ snapshots:
   is-interactive@2.0.0: {}
 
   is-map@2.0.3: {}
+
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   is-negative-zero@2.0.3: {}
 
@@ -11178,7 +11357,11 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jmespath@0.16.0: {}
+
   jose@6.2.2: {}
+
+  js-base64@3.7.2: {}
 
   js-tokens@10.0.0: {}
 
@@ -11255,6 +11438,8 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonrepair@3.13.2: {}
+
   jsonwebtoken@9.0.3:
     dependencies:
       jws: 4.0.1
@@ -11267,6 +11452,8 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.7.4
+
+  jssha@3.3.1: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -11394,6 +11581,8 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
+  lodash@4.17.23: {}
+
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.6.2
@@ -11432,6 +11621,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  luxon@3.4.4: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -11460,6 +11651,12 @@ snapshots:
       remove-accents: 0.5.0
 
   math-intrinsics@1.1.0: {}
+
+  md5@2.3.0:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
 
   mdast-util-definitions@5.1.2:
     dependencies:
@@ -12344,6 +12541,27 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
+  n8n-workflow@1.120.10:
+    dependencies:
+      '@n8n/errors': 0.5.0
+      '@n8n/tournament': 1.0.6
+      ast-types: 0.16.1
+      callsites: 3.1.0
+      esprima-next: 5.8.4
+      form-data: 4.0.0
+      jmespath: 0.16.0
+      js-base64: 3.7.2
+      jsonrepair: 3.13.2
+      jssha: 3.3.1
+      lodash: 4.17.23
+      luxon: 3.4.4
+      md5: 2.3.0
+      recast: 0.22.0
+      title-case: 3.0.3
+      transliteration: 2.3.5
+      xml2js: 0.6.2
+      zod: 3.25.67
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.4: {}
@@ -12583,6 +12801,11 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
@@ -12977,6 +13200,14 @@ snapshots:
 
   reading-time@1.5.0: {}
 
+  recast@0.22.0:
+    dependencies:
+      assert: 2.1.0
+      ast-types: 0.15.2
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tslib: 2.8.1
+
   recast@0.23.11:
     dependencies:
       ast-types: 0.16.1
@@ -13282,6 +13513,8 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  sax@1.6.0: {}
 
   saxes@6.0.0:
     dependencies:
@@ -13727,6 +13960,10 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  title-case@3.0.3:
+    dependencies:
+      tslib: 2.8.1
+
   title@3.5.3:
     dependencies:
       arg: 1.0.0
@@ -13765,6 +14002,10 @@ snapshots:
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+
+  transliteration@2.3.5:
+    dependencies:
+      yargs: 17.7.2
 
   tree-kill@1.2.2: {}
 
@@ -14061,6 +14302,14 @@ snapshots:
       react: 19.2.4
 
   util-deprecate@1.0.2: {}
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.20
 
   utils-merge@1.0.1: {}
 
@@ -14382,6 +14631,13 @@ snapshots:
 
   xml-name-validator@5.0.0: {}
 
+  xml2js@0.6.2:
+    dependencies:
+      sax: 1.6.0
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
+
   xmlbuilder@13.0.2: {}
 
   xmlchars@2.2.0: {}
@@ -14424,6 +14680,8 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.25.67: {}
 
   zod@3.25.76: {}
 

--- a/website/pages/_meta.js
+++ b/website/pages/_meta.js
@@ -2,7 +2,7 @@ export default {
   "index": "Introduction",
   "getting-started": "Getting Started",
   "clients": "Client Integrations",
-  "integrations": "Other Integrations",
+  "integrations": "Integrations",
   "consumer": "For AI Agents (Consumer)",
   "expert": "For Human Experts",
   "best-practices": "Summoning Guidelines",

--- a/website/pages/clients/overview.mdx
+++ b/website/pages/clients/overview.mdx
@@ -4,6 +4,14 @@ HeySummon connects AI coding agents to human experts. When an agent gets stuck, 
 
 HeySummon supports multiple AI platforms. Each platform has its own installation method, but the underlying API and scripts are the same.
 
+## AI coding clients vs workflow orchestrators
+
+This section covers **AI coding clients** -- tools an engineer drives at a keyboard, like [Claude Code](/clients/claude-code), [Codex CLI](/clients/codex), [Gemini CLI](/clients/gemini), and [OpenClaw](/clients/openclaw). The skill is installed once per machine and the agent calls HeySummon when it gets stuck mid-task.
+
+If you are wiring HeySummon into a **workflow orchestrator** -- something that runs unattended jobs on a server, like n8n -- see [Integrations -> Orchestrators](/integrations/orchestrators/n8n) instead. The orchestrator nodes share the same Consumer API but install differently and run inside the orchestrator runtime.
+
+*See also:* [Integrations](/integrations/orchestrators/n8n).
+
 ## Supported Platforms
 
 | Platform | Install Method | Skill Location |

--- a/website/pages/integrations/_meta.js
+++ b/website/pages/integrations/_meta.js
@@ -1,3 +1,6 @@
 export default {
+  "_channels": { type: "separator", title: "Channels" },
   "twilio": "Twilio Voice",
+  "_orchestrators": { type: "separator", title: "Orchestrators" },
+  "orchestrators": "Orchestrators",
 }

--- a/website/pages/integrations/orchestrators/_meta.js
+++ b/website/pages/integrations/orchestrators/_meta.js
@@ -1,0 +1,7 @@
+export default {
+  "n8n": "n8n",
+  "langgraph": "LangGraph",
+  "crewai": "CrewAI",
+  "make": "Make",
+  "zapier": "Zapier",
+}

--- a/website/pages/integrations/orchestrators/crewai.mdx
+++ b/website/pages/integrations/orchestrators/crewai.mdx
@@ -1,0 +1,10 @@
+# CrewAI
+
+HeySummon for CrewAI is on the roadmap.
+
+Until a first-party node ships, CrewAI users can call HeySummon directly from a tool using the [Consumer API](/consumer/api-reference) -- the same surface the [n8n](/integrations/orchestrators/n8n) node sits on top of.
+
+## Stay in the loop
+
+- Track progress: [GitHub issues](https://github.com/thomasansems/heysummon/issues)
+- See what shipped in the last cycle: [Changelog](/reference/changelog)

--- a/website/pages/integrations/orchestrators/langgraph.mdx
+++ b/website/pages/integrations/orchestrators/langgraph.mdx
@@ -1,0 +1,10 @@
+# LangGraph
+
+HeySummon for LangGraph is on the roadmap.
+
+The next orchestrator integrations will follow the priority laid out in the strategy positioning brief. In the meantime, LangGraph users can call HeySummon directly from a node using the [Consumer API](/consumer/api-reference) -- the same surface the [n8n](/integrations/orchestrators/n8n) node sits on top of.
+
+## Stay in the loop
+
+- Track progress: [GitHub issues](https://github.com/thomasansems/heysummon/issues)
+- See what shipped in the last cycle: [Changelog](/reference/changelog)

--- a/website/pages/integrations/orchestrators/make.mdx
+++ b/website/pages/integrations/orchestrators/make.mdx
@@ -1,0 +1,10 @@
+# Make
+
+HeySummon for Make is on the roadmap.
+
+A Make module is reserved as a first-class integration. Until it ships, Make users can call the HeySummon [Consumer API](/consumer/api-reference) from an HTTP module -- the same surface the [n8n](/integrations/orchestrators/n8n) node sits on top of.
+
+## Stay in the loop
+
+- Track progress: [GitHub issues](https://github.com/thomasansems/heysummon/issues)
+- See what shipped in the last cycle: [Changelog](/reference/changelog)

--- a/website/pages/integrations/orchestrators/n8n.mdx
+++ b/website/pages/integrations/orchestrators/n8n.mdx
@@ -1,0 +1,144 @@
+import { Callout } from 'nextra/components'
+
+# n8n
+
+HeySummon plugs into [n8n](https://n8n.io) as a community node. Drop the **HeySummon** node into any workflow to pause execution, summon a human expert, and resume on the answer -- with the same end-to-end encryption, lifecycle, and audit trail that HeySummon gives every other client.
+
+## Why HeySummon for n8n
+
+n8n already has well-loved channel nodes -- Discord, Gmail, Outlook -- that can post a message and wait for a reply. They notify a human, but they don't *structure* the request: there is no encrypted thread, no expert routing, no lifecycle (pending -> active -> closed/expired), and no audit trail beyond the channel's own message history.
+
+HeySummon adds that structure on top. The node sends a typed help request to your self-hosted instance over an encrypted channel, the expert responds in the HeySummon dashboard (or over Telegram, Slack, or any wired channel), and the node resumes with a typed response payload. The expert never has to context-switch back into the n8n UI.
+
+## Install
+
+In your self-hosted n8n instance:
+
+1. Open **Settings -> Community Nodes**.
+2. Click **Install**.
+3. Enter `n8n-nodes-heysummon` and confirm.
+4. Restart n8n if prompted.
+
+Or install manually inside your n8n container:
+
+```bash
+npm install n8n-nodes-heysummon
+```
+
+<Callout type="info">
+The package follows n8n's `n8n-nodes-*` naming convention and is tagged with the `n8n-community-node-package` keyword required by the community installer filter.
+</Callout>
+
+## Set up the credential
+
+Create a new credential of type **HeySummon API**:
+
+| Field | Value |
+| --- | --- |
+| API Key | A client API key (`hs_cli_*`) from your HeySummon dashboard. |
+| Base URL | The URL of your self-hosted HeySummon instance, e.g. `https://heysummon.example.com`. |
+| End-to-End Encryption | Leave on (default). See [E2E and Get Status](#e2e-and-get-status) below if you need to disable it. |
+
+Hit **Test** -- n8n calls `GET /api/v1/health` on your instance. A green tick means you're wired up.
+
+## Operations
+
+The HeySummon node exposes one resource with two operations.
+
+### Summon
+
+Blocks the workflow execution and waits for a human expert to answer.
+
+| Parameter | Required | Default | Description |
+| --- | --- | --- | --- |
+| Question | yes | -- | The plaintext question for the expert. Supports n8n expression syntax. |
+| Context | no | -- | Optional background sent as the first encrypted message after key exchange. |
+| Expert Name | no | -- | Route the request to a specific expert by name. |
+| Requires Approval | no | `false` | Surface as an Approve/Deny prompt in the dashboard. |
+| Summoning Guidelines | no | -- | Per-call override of the `HEYSUMMON_SUMMON_CONTEXT` rules. |
+| Timeout (ms) | yes | `900000` | Local timeout in milliseconds (default 15 minutes). |
+| Poll Interval (ms) | yes | `2000` | How often the node polls for the answer. |
+
+On success, returns:
+
+```json
+{
+  "requestId": "cm...",
+  "refCode": "HS-A1B2C3D4",
+  "status": "responded",
+  "response": "Plaintext answer (decrypted in process when E2E is on).",
+  "responder": "expert-name-or-null",
+  "respondedAt": "2026-04-20T18:30:00.000Z",
+  "latencyMs": 87412,
+  "messageCount": 3
+}
+```
+
+### Get Status
+
+A single non-blocking poll for an existing request.
+
+| Parameter | Required | Default | Description |
+| --- | --- | --- | --- |
+| Request ID | yes | -- | The `requestId` returned by a previous Summon call. |
+
+Returns metadata only when E2E is on (the default). See [E2E and Get Status](#e2e-and-get-status).
+
+## Errors
+
+Both operations return a structured error envelope on failure:
+
+```json
+{
+  "error": {
+    "kind": "timeout | expired | network | http | guard_rejected | validation",
+    "message": "Human readable explanation",
+    "requestId": "cm... or null",
+    "refCode": "HS-... or null",
+    "httpStatus": 504,
+    "retriable": false
+  }
+}
+```
+
+When **Continue On Fail** is enabled on the node, errors are emitted on the second output port instead of throwing.
+
+## Example workflow
+
+A minimal approval flow:
+
+```
+Webhook (POST /deploy)
+  -> AI Agent (drafts changes)
+  -> HeySummon (Summon)        question = "Approve this deploy?", requiresApproval = true
+  -> If
+       approved -> Continue: kick off the deploy job
+       denied   -> End: post the reason back to the requester
+```
+
+Larger templates (with sample workflow JSON exports) ship separately as part of the launch announcement -- watch [the changelog](/reference/changelog) for the link.
+
+## Self-hosted base URL
+
+HeySummon is currently self-hosted only. The Base URL on the credential **must** point at your own instance -- there is no managed cloud endpoint to leave the field blank for. If you have not stood up an instance yet, see [Self-Hosting](/self-hosting/overview).
+
+## E2E and Get Status
+
+End-to-end encryption is on by default. The HeySummon node generates an ephemeral X25519 keypair *for each Summon execution* and decrypts the expert's response in process. Those keys live only in memory and are dropped when the execution finishes.
+
+That has one important consequence: a `Get Status` call in a *different* execution cannot decrypt the response, because the keypair from the original Summon is gone. With the default E2E setting, `Get Status` returns metadata only -- `response` is always `null`.
+
+If you need cross-execution access to the decrypted response (e.g. a separate "follow up" workflow that polls a long-running ticket), set **End-to-End Encryption** to off on the credential. The credential test result will show a yellow "E2E disabled" badge so you don't ship that setting to production by accident.
+
+## Limits and roadmap
+
+- Single-vendor scope. The node implements one resource with two operations -- no Discord/Gmail/Outlook channel selectors. HeySummon channels are configured on the HeySummon side instead.
+- Cross-execution decrypted polling requires E2E off (see above).
+- Polling-trigger and webhook-trigger nodes are on the roadmap, not in this release.
+- Other orchestrators ([LangGraph](/integrations/orchestrators/langgraph), [CrewAI](/integrations/orchestrators/crewai), [Make](/integrations/orchestrators/make), [Zapier](/integrations/orchestrators/zapier)) are reserved as nav slots and ship later.
+
+## Links
+
+- npm package: [`n8n-nodes-heysummon`](https://www.npmjs.com/package/n8n-nodes-heysummon)
+- Source: [`packages/n8n-nodes-heysummon/`](https://github.com/thomasansems/heysummon/tree/main/packages/n8n-nodes-heysummon)
+- Issues / feedback: [GitHub issues](https://github.com/thomasansems/heysummon/issues)

--- a/website/pages/integrations/orchestrators/n8n.mdx
+++ b/website/pages/integrations/orchestrators/n8n.mdx
@@ -55,7 +55,6 @@ Blocks the workflow execution and waits for a human expert to answer.
 | Context | no | -- | Optional background sent as the first encrypted message after key exchange. |
 | Expert Name | no | -- | Route the request to a specific expert by name. |
 | Requires Approval | no | `false` | Surface as an Approve/Deny prompt in the dashboard. |
-| Summoning Guidelines | no | -- | Per-call override of the `HEYSUMMON_SUMMON_CONTEXT` rules. |
 | Timeout (ms) | yes | `900000` | Local timeout in milliseconds (default 15 minutes). |
 | Poll Interval (ms) | yes | `2000` | How often the node polls for the answer. |
 

--- a/website/pages/integrations/orchestrators/zapier.mdx
+++ b/website/pages/integrations/orchestrators/zapier.mdx
@@ -1,0 +1,10 @@
+# Zapier
+
+HeySummon for Zapier is on the roadmap.
+
+A Zapier app is reserved as a first-class integration. Until it ships, Zapier users can call the HeySummon [Consumer API](/consumer/api-reference) from a Webhooks step -- the same surface the [n8n](/integrations/orchestrators/n8n) node sits on top of.
+
+## Stay in the loop
+
+- Track progress: [GitHub issues](https://github.com/thomasansems/heysummon/issues)
+- See what shipped in the last cycle: [Changelog](/reference/changelog)

--- a/website/pages/reference/changelog.mdx
+++ b/website/pages/reference/changelog.mdx
@@ -4,8 +4,14 @@ import { Callout } from 'nextra/components'
 
 ## Unreleased
 
+### Added
+- **n8n community node:** new `n8n-nodes-heysummon` package adds a HeySummon node to any n8n workflow. Two operations -- `Summon` (blocking ask with timeout) and `Get Status` (poll an existing request). Auth via a `HeySummon API` n8n credential type. Self-hosted base URL is a first-class input. End-to-end encryption is on by default; the lifecycle constraint between `Summon` and `Get Status` is documented on the integration page. The package ships under MIT to qualify for n8n's Verified Community Nodes program
+
 ### Changed
 - **Messaging:** headline USP updated from "end-to-end encrypted" to "platform agnostic" across the landing page, marketing site, READMEs, and docs home. Encryption remains a core security feature and is still documented in `/security/` and `/consumer/encryption`, but the primary positioning now emphasizes that HeySummon works with any agent framework, any model, and any notification channel — no SDK lock-in, no vendor tie
+- **Integrations IA:** `website/pages/integrations/` reorganised into **Channels** (Twilio) and **Orchestrators** (n8n now; LangGraph, CrewAI, Make, Zapier reserved as coming-soon). Top nav label updated from "Other Integrations" to "Integrations"
+- **`clients/overview.mdx`:** adds a short clarifier distinguishing AI coding clients (Claude Code, Codex, Gemini, OpenClaw) from workflow orchestrators (n8n), with a link forward to the orchestrators section
+- **Consumer SDK:** `HeySummonClientOptions` now accepts optional `userAgent` and `extraHeaders` fields, threaded through every outbound request. Existing callers are unaffected. Used by the n8n node to attribute outbound traffic per PRD §4.8
 
 ---
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,0 +1,69 @@
+# HeySummon
+
+> HeySummon is the open-source, self-hosted, platform-agnostic human-in-the-loop (HITL) platform for AI agents. When an AI agent gets stuck, needs approval, or lacks context, it sends an encrypted help request to a human expert who responds through the dashboard, Telegram, Slack, or another channel. The agent picks up the response and continues its workflow.
+
+HeySummon works with any AI agent that can make HTTP requests -- Claude Code, Codex, Gemini, OpenClaw, LangChain, n8n, or custom agents. Experts respond through a web dashboard, Telegram, Slack, or other supported channels. All communication is end-to-end encrypted using X25519 key exchange and AES-256-GCM.
+
+The platform is self-hosted: run it on your infrastructure with `npx @heysummon/app`, Docker Compose, or from source. Your data never leaves your servers.
+
+## Docs
+
+- [Getting Started / Quickstart](https://docs.heysummon.ai/getting-started/quickstart): Install and run HeySummon in under 5 minutes using NPX, Docker, or from source
+- [How It Works](https://docs.heysummon.ai/getting-started/how-it-works): The full request lifecycle from agent question to expert answer
+- [Concepts](https://docs.heysummon.ai/getting-started/concepts): Key terminology -- Consumer, Expert, HelpRequest, Channel, Guard
+- [Best Practices](https://docs.heysummon.ai/best-practices): Guidelines for when and how agents should summon human help
+
+## Consumer (AI Agent) Integration
+
+- [Consumer Overview](https://docs.heysummon.ai/consumer/overview): How AI agents connect to and use HeySummon
+- [Consumer API Reference](https://docs.heysummon.ai/consumer/api-reference): HTTP API endpoints for submitting and polling help requests
+- [Real-time Events](https://docs.heysummon.ai/consumer/realtime): Polling and real-time event handling for agent integrations
+- [Consumer Encryption](https://docs.heysummon.ai/consumer/encryption): End-to-end encryption implementation for consumer requests
+
+## Client Platform Guides
+
+- [Claude Code](https://docs.heysummon.ai/clients/claude-code): Set up HeySummon as a skill in Claude Code
+- [Codex CLI](https://docs.heysummon.ai/clients/codex): Integrate with OpenAI Codex CLI
+- [Gemini CLI](https://docs.heysummon.ai/clients/gemini): Integrate with Google Gemini CLI
+- [OpenClaw](https://docs.heysummon.ai/clients/openclaw): Integrate with OpenClaw agents
+
+## Orchestrator Integrations
+
+- [n8n](https://docs.heysummon.ai/integrations/orchestrators/n8n): Add a human-in-the-loop step to any n8n workflow with the n8n-nodes-heysummon community node
+
+## Expert (Human) Dashboard
+
+- [Expert Overview](https://docs.heysummon.ai/expert/overview): The expert role and how to get started responding to agent requests
+- [Dashboard Guide](https://docs.heysummon.ai/expert/dashboard): Using the web dashboard to review and respond to help requests
+- [Conversations](https://docs.heysummon.ai/expert/conversations): Managing multi-turn conversations with agents
+- [API Keys](https://docs.heysummon.ai/expert/api-keys): Creating and managing API keys for agent authentication
+
+## Security
+
+- [Security Overview](https://docs.heysummon.ai/security/overview): Security architecture including Guard proxy, E2E encryption, and defense layers
+- [API Security](https://docs.heysummon.ai/security/api-security): API authentication, rate limiting, and access control
+- [Encryption](https://docs.heysummon.ai/security/encryption): X25519 key exchange and AES-256-GCM encryption details
+- [Content Safety](https://docs.heysummon.ai/security/content-safety-guard): Content safety middleware, XSS prevention, and PII filtering
+
+## Self-Hosting
+
+- [Self-Hosting Overview](https://docs.heysummon.ai/self-hosting/overview): Deployment options -- NPX, Docker Compose, or from source
+- [Docker Setup](https://docs.heysummon.ai/self-hosting/docker): Docker Compose deployment with Caddy, Cloudflare, or Tailscale
+- [NPX Installer](https://docs.heysummon.ai/self-hosting/npx): One-command install with npx @heysummon/app
+- [Environment Variables](https://docs.heysummon.ai/self-hosting/environment-variables): All configuration options and environment variables
+- [Architecture](https://docs.heysummon.ai/self-hosting/architecture): System architecture diagram and component overview
+- [Database](https://docs.heysummon.ai/self-hosting/database): SQLite and PostgreSQL setup
+
+## Reference
+
+- [Full API Reference](https://docs.heysummon.ai/reference/api): Complete API endpoint documentation with request/response examples
+- [Message Flow](https://docs.heysummon.ai/reference/message-flow): Detailed encrypted message flow diagrams
+- [Changelog](https://docs.heysummon.ai/reference/changelog): Release notes and version history
+
+## Optional
+
+Other integrations -- including orchestrators -- live in the dedicated section above.
+
+- [Contributing](https://docs.heysummon.ai/contributing): How to contribute to HeySummon
+- [Twilio Voice Integration](https://docs.heysummon.ai/integrations/twilio): Set up voice-based expert responses via Twilio
+- [Source Code](https://github.com/thomasansems/heysummon): GitHub repository


### PR DESCRIPTION
## Summary

Adds the `n8n-nodes-heysummon` community node so any n8n workflow can pause, summon a human expert via HeySummon, and resume on the answer. Restructures the docs IA so n8n is the first orchestrator and the next four (LangGraph, CrewAI, Make, Zapier) have reserved nav slots.

- Parent issue: [HEY-238](/HEY/issues/HEY-238) — see [plan](/HEY/issues/HEY-238#document-plan)
- Spec: [HEY-231 PRD rev 2](/HEY/issues/HEY-231#document-prd)
- Build issue: [HEY-239](/HEY/issues/HEY-239)

## What changed

- New package ` packages/n8n-nodes-heysummon/` — two operations (Summon, Get Status), one credential type (HeySummonApi), MIT licensed for n8n's Verified Community Nodes program.
- Consumer SDK: optional `userAgent` and `extraHeaders` on `HeySummonClientOptions`, threaded through every outbound call. No breaking change.
- All HTTP routes through `@heysummon/consumer-sdk` — no inline `fetch`, no re-implemented crypto.
- `User-Agent: n8n-nodes-heysummon/<package-version> (n8n; node)` set on every outbound call, version read from the package's own `package.json` at runtime.
- Docs IA: `website/pages/integrations/_meta.js` reorganised into Channels + Orchestrators; new `integrations/orchestrators/n8n.mdx` plus four coming-soon stubs; nav label changed from "Other Integrations" to "Integrations"; `clients/overview.mdx` clarifier added.
- Changelog entry under `## Unreleased`. Both `llms.txt` files (website + landing) updated in the same commit so they cannot drift.
- Root `LICENSE.md`: one-line MIT carve-out note for the new package.

## Acceptance criteria (PRD §8)

### 8.1 Code
- [x] `packages/n8n-nodes-heysummon/` exists with `package.json`, `tsconfig.json`, `src/`, follows repo conventions.
- [x] `packages/n8n-nodes-heysummon/LICENSE` is MIT; root `LICENSE.md` references the per-package MIT carve-out.
- [x] One node (`HeySummon`) and one credential type (`HeySummonApi`) exported per the n8n community node format.
- [x] Both operations (`Summon`, `Get Status`) implemented with parameters, defaults, validation, and output schemas exactly per §4.3 and §4.4.
- [x] Credential `test` button hits `GET /api/v1/health` and reports success/failure.
- [x] All HTTP calls go through `@heysummon/consumer-sdk` — no inline `fetch` to HeySummon endpoints; no re-implemented crypto.
- [x] All outbound HTTP calls set `User-Agent: n8n-nodes-heysummon/<package-version> (n8n; node)`, version sourced from `package.json` at runtime.
- [x] Error envelope matches §4.4.2 exactly. \"Continue On Fail\" honoured.
- [x] `pnpm build` from the package root produces a publishable artefact under `dist/`.

### 8.2 Tests
- [x] Unit tests cover: parameter validation, success path for `Summon`, expired path, timeout path, network-error path, `Get Status` happy path, `Get Status` E2E-on metadata-only response.
- [x] Unit test asserts the outbound `User-Agent` header is set on at least one outbound call and contains `n8n-nodes-heysummon/` followed by the version from `package.json`.
- [x] Tests use Vitest and live alongside the package.

### 8.3 Docs
- [x] `website/pages/integrations/_meta.js` matches §5.1.
- [x] `website/pages/integrations/orchestrators/n8n.mdx` exists with all sections in §5.2.
- [x] `website/pages/integrations/orchestrators/{langgraph,crewai,make,zapier}.mdx` stubs exist per §5.3.
- [x] `website/pages/_meta.js` label updated per §5.4.
- [x] `website/pages/clients/overview.mdx` clarifier added per §5.5.
- [x] Changelog entry from §6 added under `## Unreleased`.
- [x] `website/public/llms.txt` and `landingspage/public/llms.txt` updated in the same commit per §7.

### 8.4 Publishing target (preparation only)
- [x] `package.json` `name` is `n8n-nodes-heysummon` (unscoped).
- [x] `package.json` `license` is `MIT`.
- [x] `package.json` `publishConfig.access` is `\"public\"`.
- [x] `package.json` `keywords` includes `n8n`, `n8n-community-node-package`, `hitl`, `human-in-the-loop`.
- [x] `package.json` `repository.url` points at the monorepo with `directory: \"packages/n8n-nodes-heysummon\"`.
- [x] README covers install, credential, both operations, the User-Agent attribution note, and links to the docs page.

## Test plan

- [x] `pnpm --filter n8n-nodes-heysummon run build` — green
- [x] `pnpm --filter n8n-nodes-heysummon run lint` — green
- [x] `pnpm --filter n8n-nodes-heysummon run test` — 13/13 passing
- [x] `pnpm --filter @heysummon/consumer-sdk run build` — green
- [x] `pnpm --filter @heysummon/consumer-sdk run test` — 54 new + existing tests pass; one pre-existing failure on \`provider is not defined\` is unrelated to this PR (present on main).
- [x] `pnpm test` (root vitest) — 288/288 passing
- [x] `pnpm build` (root next build) — green
- [x] `pnpm lint` (root) — 0 errors, only pre-existing warnings
- [ ] Manual smoke: install in a self-hosted n8n container and run a Summon -> approve -> resume flow
- [ ] Staff Engineer review (PRD §8 sign-off)

## Out of scope

- `npm publish` (owned by GTM on [HEY-232](/HEY/issues/HEY-232))
- n8n Verified Community Nodes submission (owned by GTM)
- Multi-vendor channel selector, polling/webhook trigger nodes, cross-execution E2E persistence, marketing copy beyond the docs page (PRD §8.5)

## Notes

- The pre-existing `decrypts mixed thread with both consumer and provider encrypted messages` test in the consumer SDK references an undefined `provider` variable. It fails on `main` already and is left untouched in this PR.
- The website Next.js build (`pnpm --filter heysummon-website run build`) fails on `main` with Nextra/Next 16 prerender errors on unrelated pages (`/expert/_meta`, `/security/overview`, `/clients/_meta`). Out of scope here.
- The `landingspage/public/llms.txt` and `website/public/llms.txt` files are introduced on this branch even though a parallel branch (`feat/add-llms-txt`) also adds them. Whichever lands first, the other will need a trivial merge — the n8n additions are the only delta in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)