### PR TITLE
fix(onboarding): unblock multi-user dashboard access (HEY-226)

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -386,8 +386,28 @@ async function main() {
     console.log("✅ Playwright OpenClaw channel exists");
   }
 
+  // Secondary Playwright user — represents a second user added AFTER the admin
+  // finished onboarding. `onboardingComplete: false` reproduces HEY-226: the
+  // dashboard's OnboardingGuard should see the platform already configured
+  // (globally) and let them through without a wizard redirect.
+  const pwSecondPassword = await bcrypt.hash("PlaywrightTest123!", 12);
+  await prisma.user.upsert({
+    where: { email: "playwright-second@heysummon.test" },
+    update: {},
+    create: {
+      email: "playwright-second@heysummon.test",
+      name: "Playwright Second User",
+      password: pwSecondPassword,
+      role: "expert",
+      onboardingComplete: false,
+      notificationPref: "email",
+    },
+  });
+  console.log(`✅ Playwright second user: playwright-second@heysummon.test (onboardingComplete=false)`);
+
   console.log("\n📋 Playwright test constants:");
   console.log(`   User:          playwright@heysummon.test / PlaywrightTest123!`);
+  console.log(`   Second user:   playwright-second@heysummon.test / PlaywrightTest123!`);
   console.log(`   Expert key:    hs_exp_playwright00000000000000000001`);
   console.log(`   Base key:      hs_cli_playwright00000000000000000001`);
   console.log(`   OC→Telegram:   hs_cli_pw_openclaw_telegram_00000001`);

--- a/src/__tests__/onboarding-status.test.ts
+++ b/src/__tests__/onboarding-status.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUser: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    userProfile: { count: vi.fn() },
+    apiKey: { count: vi.fn() },
+    user: { update: vi.fn() },
+  },
+}));
+
+import { getCurrentUser } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { GET } from "@/app/api/onboarding/status/route";
+
+const mockGetCurrentUser = vi.mocked(getCurrentUser);
+const mockUserProfileCount = vi.mocked(prisma.userProfile.count);
+const mockApiKeyCount = vi.mocked(prisma.apiKey.count);
+const mockUserUpdate = vi.mocked(prisma.user.update);
+
+type MinimalUser = {
+  id: string;
+  email: string;
+  name: string | null;
+  role: string;
+  onboardingComplete: boolean;
+};
+
+function makeUser(overrides: Partial<MinimalUser> = {}): MinimalUser {
+  return {
+    id: "user-1",
+    email: "user@example.com",
+    name: "User One",
+    role: "admin",
+    onboardingComplete: false,
+    ...overrides,
+  };
+}
+
+describe("GET /api/onboarding/status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserUpdate.mockResolvedValue({} as never);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("T1: first run — no experts, no keys, onboardingComplete false", async () => {
+    mockGetCurrentUser.mockResolvedValue(makeUser({ id: "admin-1", onboardingComplete: false }) as never);
+    mockUserProfileCount.mockResolvedValue(0);
+    mockApiKeyCount.mockResolvedValue(0);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      onboardingComplete: false,
+      hasExpert: false,
+      hasClient: false,
+      expertCount: 0,
+      clientCount: 0,
+    });
+    expect(mockUserUpdate).not.toHaveBeenCalled();
+  });
+
+  it("T2: second user — platform configured, flips onboardingComplete to true", async () => {
+    mockGetCurrentUser.mockResolvedValue(makeUser({ id: "user-2", onboardingComplete: false }) as never);
+    mockUserProfileCount.mockResolvedValue(1);
+    mockApiKeyCount.mockResolvedValue(1);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      onboardingComplete: true,
+      hasExpert: true,
+      hasClient: true,
+      expertCount: 1,
+      clientCount: 1,
+    });
+    expect(mockUserUpdate).toHaveBeenCalledWith({
+      where: { id: "user-2" },
+      data: { onboardingComplete: true },
+    });
+  });
+
+  it("T3: admin already complete — no DB write", async () => {
+    mockGetCurrentUser.mockResolvedValue(makeUser({ id: "admin-1", onboardingComplete: true }) as never);
+    mockUserProfileCount.mockResolvedValue(1);
+    mockApiKeyCount.mockResolvedValue(1);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      onboardingComplete: true,
+      hasExpert: true,
+      hasClient: true,
+    });
+    expect(mockUserUpdate).not.toHaveBeenCalled();
+  });
+
+  it("T4: partial setup (expert but no key) — no flip, guard still routes to onboarding", async () => {
+    mockGetCurrentUser.mockResolvedValue(makeUser({ id: "admin-1", onboardingComplete: false }) as never);
+    mockUserProfileCount.mockResolvedValue(1);
+    mockApiKeyCount.mockResolvedValue(0);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      onboardingComplete: false,
+      hasExpert: true,
+      hasClient: false,
+      expertCount: 1,
+      clientCount: 0,
+    });
+    expect(mockUserUpdate).not.toHaveBeenCalled();
+  });
+
+  it("uses global counts, never filters by user id", async () => {
+    mockGetCurrentUser.mockResolvedValue(makeUser({ onboardingComplete: true }) as never);
+    mockUserProfileCount.mockResolvedValue(5);
+    mockApiKeyCount.mockResolvedValue(3);
+
+    await GET();
+
+    expect(mockUserProfileCount).toHaveBeenCalledWith();
+    expect(mockApiKeyCount).toHaveBeenCalledWith();
+  });
+});

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -7,9 +7,20 @@ export async function GET() {
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const [expertCount, clientCount] = await Promise.all([
-    prisma.userProfile.count({ where: { userId: user.id } }),
-    prisma.apiKey.count({ where: { userId: user.id } }),
+    prisma.userProfile.count(),
+    prisma.apiKey.count(),
   ]);
+
+  const platformConfigured = expertCount > 0 && clientCount > 0;
+
+  let onboardingComplete = user.onboardingComplete;
+  if (!onboardingComplete && platformConfigured) {
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { onboardingComplete: true },
+    });
+    onboardingComplete = true;
+  }
 
   let tunnelActive = false;
   try {
@@ -23,7 +34,7 @@ export async function GET() {
   }
 
   return NextResponse.json({
-    onboardingComplete: user.onboardingComplete,
+    onboardingComplete,
     hasExpert: expertCount > 0,
     hasClient: clientCount > 0,
     tunnelActive,

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -3,6 +3,10 @@ export const PW = {
   EMAIL: "playwright@heysummon.test",
   PASSWORD: "PlaywrightTest123!",
 
+  /** Second user seeded with onboardingComplete=false to reproduce HEY-226 */
+  SECOND_EMAIL: "playwright-second@heysummon.test",
+  SECOND_PASSWORD: "PlaywrightTest123!",
+
   EXPERT_KEY: "hs_exp_playwright00000000000000000001",
 
   /** Base lifecycle test key */

--- a/tests/e2e/multi-user-onboarding.spec.ts
+++ b/tests/e2e/multi-user-onboarding.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect, Page } from "@playwright/test";
+import { BASE_URL, PW } from "./helpers/constants";
+
+async function login(page: Page, email: string, password: string) {
+  await page.goto(`${BASE_URL}/auth/login`);
+  await page.waitForSelector("#email", { timeout: 10000 });
+  await page.locator("#email").fill(email);
+  await page.locator("#password").fill(password);
+  await Promise.all([
+    page.waitForURL(/\/dashboard/, { timeout: 15000 }),
+    page.locator('button[type="submit"]').click(),
+  ]);
+}
+
+/**
+ * HEY-226 / HEY-252: Multi-user dashboard onboarding loop.
+ *
+ * When the platform is already configured (at least one expert and one API key
+ * exist globally), a second user with `onboardingComplete=false` must land on
+ * `/dashboard` directly — not be bounced to `/onboarding`.
+ */
+test.describe("Multi-user onboarding — HEY-226", () => {
+  test("second user (onboardingComplete=false) lands on /dashboard, never visits /onboarding", async ({ page }) => {
+    const visitedOnboarding: string[] = [];
+    page.on("framenavigated", (frame) => {
+      if (frame === page.mainFrame() && frame.url().includes("/onboarding")) {
+        visitedOnboarding.push(frame.url());
+      }
+    });
+
+    await login(page, PW.SECOND_EMAIL, PW.SECOND_PASSWORD);
+
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
+
+    // Give OnboardingGuard time to finish its fetch and settle
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    expect(visitedOnboarding, `URL should never visit /onboarding: ${visitedOnboarding.join(", ")}`).toHaveLength(0);
+  });
+
+  test("second user's onboardingComplete is auto-flipped to true by status route", async ({ page }) => {
+    await login(page, PW.SECOND_EMAIL, PW.SECOND_PASSWORD);
+
+    const res = await page.request.get(`${BASE_URL}/api/onboarding/status`);
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+
+    expect(data).toMatchObject({
+      onboardingComplete: true,
+      hasExpert: true,
+      hasClient: true,
+    });
+    expect(data.expertCount).toBeGreaterThan(0);
+    expect(data.clientCount).toBeGreaterThan(0);
+  });
+});

--- a/website/pages/expert/overview.mdx
+++ b/website/pages/expert/overview.mdx
@@ -12,6 +12,11 @@ An **expert** is a human expert who answers help requests from AI agents.
 4. Set up the [watcher](/expert/conversations) to receive notifications
 5. Start responding to requests
 
+<Callout type="info">
+  Additional users added after the first instance setup skip the onboarding wizard.
+  Onboarding is a platform-level setup that runs once per instance, not once per user.
+</Callout>
+
 ## How you receive requests
 
 | Channel | How |

--- a/website/pages/reference/changelog.mdx
+++ b/website/pages/reference/changelog.mdx
@@ -4,6 +4,9 @@ import { Callout } from 'nextra/components'
 
 ## Unreleased
 
+### Fixed
+- **Multi-user dashboard onboarding loop.** Users added after the first instance setup are no longer bounced into the onboarding wizard. The `/api/onboarding/status` route now returns platform-global expert and API key counts (previously scoped per-user), so `OnboardingGuard` recognises that the platform is already configured and lets additional users through to the dashboard. Their `user.onboardingComplete` flag is auto-flipped to `true` on first call so the check is cheap on subsequent page loads (HEY-226)
+
 ### Added
 - **n8n community node:** new `n8n-nodes-heysummon` package adds a HeySummon node to any n8n workflow. Two operations -- `Summon` (blocking ask with timeout) and `Get Status` (poll an existing request). Auth via a `HeySummon API` n8n credential type. Self-hosted base URL is a first-class input. End-to-end encryption is on by default; the lifecycle constraint between `Summon` and `Get Status` is documented on the integration page. The package ships under MIT to qualify for n8n's Verified Community Nodes program
 


### PR DESCRIPTION
## Summary
- Switches `/api/onboarding/status` from per-user to platform-global expert + API key counts so a second user is no longer mis-routed to the onboarding wizard
- Auto-flips `user.onboardingComplete` to `true` when the platform is already configured, so the check is cheap on subsequent page loads
- Response shape is preserved — `OnboardingGuard` in `src/app/dashboard/layout.tsx` needs no changes
- Covers the plan's T1–T4 matrix with Vitest + adds a Playwright E2E seeded with a second user at `onboardingComplete=false`
- Docs: new callout under `expert/overview` and a `Fixed` changelog entry

Implements [HEY-252](/HEY/issues/HEY-252) per the [HEY-226 plan](/HEY/issues/HEY-226#document-plan).

## Test plan
- [x] `pnpm test` — 294 / 294 pass (includes 6 new `onboarding-status` cases)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — succeeds
- [x] `pnpm exec playwright test --list tests/e2e/multi-user-onboarding.spec.ts` — 2 tests registered
- [ ] `pnpm test:e2e` multi-user happy path (run in CI against seeded DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)