### PR TITLE
fix(security): close cross-tenant message read and OpenClaw approve URL forgery (HEY-403)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heysummon/app",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "HeySummon — Human-in-the-loop for AI agents. Install & run with one command.",
   "bin": {
     "heysummon": "./bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heysummon",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3425",

--- a/packages/consumer-sdk/package.json
+++ b/packages/consumer-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heysummon/consumer-sdk",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "TypeScript SDK for HeySummon consumers (AI agents)",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/__tests__/adapters/openclaw.test.ts
+++ b/src/__tests__/adapters/openclaw.test.ts
@@ -23,7 +23,14 @@ vi.mock("@/lib/public-url", () => ({
   getPublicBaseUrl: vi.fn(() => "https://heysummon.example.com"),
 }));
 
-import { openClawAdapter, sendNotification, sendNotificationWithActions, verifyWebhookSignature } from "@/lib/adapters/openclaw";
+import {
+  openClawAdapter,
+  sendNotification,
+  sendNotificationWithActions,
+  verifyWebhookSignature,
+  signQueryAction,
+  verifyQueryActionSignature,
+} from "@/lib/adapters/openclaw";
 
 describe("OpenClaw Adapter", () => {
   describe("validateConfig", () => {
@@ -178,6 +185,49 @@ describe("OpenClaw Adapter", () => {
       expect(body.actions.approve).toContain("action=approve&requestId=req-1");
       expect(body.actions.deny).toContain("action=deny&requestId=req-1");
       expect(body.callbackUrl).toBe("https://heysummon.example.com/api/adapters/openclaw/ch-1/webhook");
+
+      // Action URLs must carry an HMAC signature bound to (action, requestId)
+      // signed with the channel's webhookSecret. Without it the webhook would
+      // accept unauthenticated approve/deny calls (HEY-403).
+      const approveUrl = new URL(body.actions.approve);
+      const denyUrl = new URL(body.actions.deny);
+      const approveSig = approveUrl.searchParams.get("sig");
+      const denySig = denyUrl.searchParams.get("sig");
+      expect(approveSig).toBe(signQueryAction("secret", "approve", "req-1"));
+      expect(denySig).toBe(signQueryAction("secret", "deny", "req-1"));
+    });
+  });
+
+  describe("verifyQueryActionSignature", () => {
+    const secret = "test-webhook-secret";
+
+    it("accepts a signature produced by signQueryAction", () => {
+      const sig = signQueryAction(secret, "approve", "req-42");
+      expect(verifyQueryActionSignature(secret, "approve", "req-42", sig)).toBe(true);
+    });
+
+    it("rejects a signature for a different action", () => {
+      const sig = signQueryAction(secret, "approve", "req-42");
+      expect(verifyQueryActionSignature(secret, "deny", "req-42", sig)).toBe(false);
+    });
+
+    it("rejects a signature for a different requestId", () => {
+      const sig = signQueryAction(secret, "approve", "req-42");
+      expect(verifyQueryActionSignature(secret, "approve", "req-99", sig)).toBe(false);
+    });
+
+    it("rejects an unknown action enum", () => {
+      const sig = signQueryAction(secret, "approve", "req-42");
+      expect(verifyQueryActionSignature(secret, "delete", "req-42", sig)).toBe(false);
+    });
+
+    it("rejects an empty signature", () => {
+      expect(verifyQueryActionSignature(secret, "approve", "req-42", "")).toBe(false);
+    });
+
+    it("rejects when webhookSecret is empty", () => {
+      const sig = signQueryAction(secret, "approve", "req-42");
+      expect(verifyQueryActionSignature("", "approve", "req-42", sig)).toBe(false);
     });
   });
 

--- a/src/__tests__/api/v1-messages-idor.test.ts
+++ b/src/__tests__/api/v1-messages-idor.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    helpRequest: { findUnique: vi.fn() },
+    apiKey: { findUnique: vi.fn(), findFirst: vi.fn() },
+    rateLimit: { upsert: vi.fn() },
+    ipEvent: { findFirst: vi.fn(), upsert: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/api-key-auth", () => ({
+  validateApiKeyRequest: vi.fn(),
+  sanitizeError: (err: unknown) => err,
+}));
+
+import { prisma } from "@/lib/prisma";
+import { validateApiKeyRequest } from "@/lib/api-key-auth";
+import { GET } from "@/app/api/v1/messages/[requestId]/route";
+
+const mockFindUnique = vi.mocked(prisma.helpRequest.findUnique);
+const mockValidate = vi.mocked(validateApiKeyRequest);
+
+function makeRequest() {
+  return new Request("https://example.com/api/v1/messages/req-1", {
+    method: "GET",
+    headers: { "x-api-key": "hs_cli_caller" },
+  });
+}
+
+describe("GET /api/v1/messages/[requestId] — cross-tenant scoping (HEY-403)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 404 when the request belongs to a different API key", async () => {
+    mockValidate.mockResolvedValue({
+      ok: true,
+      apiKey: { id: "key-caller", key: "hs_cli_caller" },
+    } as never);
+    mockFindUnique.mockResolvedValue({
+      id: "req-1",
+      apiKeyId: "key-other-tenant",
+      refCode: "HS-OTHER",
+      status: "responded",
+      consumerSignPubKey: null,
+      consumerEncryptPubKey: null,
+      expertSignPubKey: null,
+      expertEncryptPubKey: null,
+      messageHistory: [
+        {
+          id: "m-1",
+          from: "expert",
+          ciphertext: "secret-blob",
+          iv: "iv",
+          authTag: "tag",
+          signature: "sig",
+          messageId: "mid-1",
+          createdAt: new Date(),
+        },
+      ],
+      expiresAt: new Date(Date.now() + 60_000),
+    } as never);
+
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ requestId: "req-1" }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Request not found" });
+  });
+
+  it("returns the messages when the API key owns the request", async () => {
+    mockValidate.mockResolvedValue({
+      ok: true,
+      apiKey: { id: "key-owner", key: "hs_cli_caller" },
+    } as never);
+    mockFindUnique.mockResolvedValue({
+      id: "req-1",
+      apiKeyId: "key-owner",
+      refCode: "HS-OWNER",
+      status: "responded",
+      consumerSignPubKey: "csp",
+      consumerEncryptPubKey: "cep",
+      expertSignPubKey: "esp",
+      expertEncryptPubKey: "eep",
+      messageHistory: [
+        {
+          id: "m-1",
+          from: "expert",
+          ciphertext: "secret-blob",
+          iv: "iv",
+          authTag: "tag",
+          signature: "sig",
+          messageId: "mid-1",
+          createdAt: new Date(),
+        },
+      ],
+      expiresAt: new Date(Date.now() + 60_000),
+    } as never);
+
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ requestId: "req-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.requestId).toBe("req-1");
+    expect(body.refCode).toBe("HS-OWNER");
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].ciphertext).toBe("secret-blob");
+  });
+
+  it("returns 404 when the request id does not exist", async () => {
+    mockValidate.mockResolvedValue({
+      ok: true,
+      apiKey: { id: "key-caller", key: "hs_cli_caller" },
+    } as never);
+    mockFindUnique.mockResolvedValue(null as never);
+
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ requestId: "req-missing" }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("propagates the auth error response when the api key is invalid", async () => {
+    const authResponse = new Response(JSON.stringify({ error: "unauth" }), {
+      status: 401,
+    });
+    mockValidate.mockResolvedValue({ ok: false, response: authResponse } as never);
+
+    const res = await GET(makeRequest(), {
+      params: Promise.resolve({ requestId: "req-1" }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(mockFindUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/adapters/openclaw/[id]/webhook/route.ts
+++ b/src/app/api/adapters/openclaw/[id]/webhook/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { randomUUID } from "crypto";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { verifyWebhookSignature } from "@/lib/adapters/openclaw";
+import { verifyWebhookSignature, verifyQueryActionSignature } from "@/lib/adapters/openclaw";
 import type { OpenClawConfig } from "@/lib/adapters/types";
 
 /** Max length for an expert reply via OpenClaw */
@@ -49,13 +49,25 @@ export async function POST(
     !signature ||
     !verifyWebhookSignature(config.webhookSecret, rawBody, signature)
   ) {
-    // Also check query-param based actions (approve/deny URLs from notification)
+    // Also check query-param based actions (approve/deny URLs from notification).
+    // The action URL must carry an HMAC signature bound to (action, requestId)
+    // signed with the channel's webhookSecret. Without this, anyone who learned
+    // a channel id and request id could forge an approve/deny call.
     const url = new URL(request.url);
     const queryAction = url.searchParams.get("action");
     const queryRequestId = url.searchParams.get("requestId");
+    const querySig = url.searchParams.get("sig");
 
-    if (queryAction && queryRequestId) {
-      return handleQueryAction(queryAction, queryRequestId, channel, config);
+    if (queryAction && queryRequestId && querySig && config.webhookSecret) {
+      const valid = verifyQueryActionSignature(
+        config.webhookSecret,
+        queryAction,
+        queryRequestId,
+        querySig,
+      );
+      if (valid) {
+        return handleQueryAction(queryAction, queryRequestId, channel, config);
+      }
     }
 
     return NextResponse.json({ error: "Invalid signature" }, { status: 403 });
@@ -84,21 +96,19 @@ export async function POST(
   return handleApproval(parsed.action, parsed.requestId, channel);
 }
 
-/** Handle query-param based approve/deny (from action URLs in notification) */
+/**
+ * Handle query-param based approve/deny.
+ * Caller in the POST handler MUST verify the action URL signature first via
+ * verifyQueryActionSignature(); this function only enforces the action enum.
+ */
 async function handleQueryAction(
   action: string,
   requestId: string,
   channel: { id: string; profile: { userId: string } },
-  config: OpenClawConfig & { webhookSecret?: string },
+  _config: OpenClawConfig & { webhookSecret?: string },
 ): Promise<NextResponse> {
   if (action !== "approve" && action !== "deny") {
     return NextResponse.json({ error: "Invalid action" }, { status: 400 });
-  }
-
-  // For query-param actions, verify via API key in Authorization header
-  const authHeader = config.webhookSecret; // The secret acts as the shared auth
-  if (!authHeader) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
   }
 
   return handleApproval(action, requestId, channel);

--- a/src/app/api/v1/messages/[requestId]/route.ts
+++ b/src/app/api/v1/messages/[requestId]/route.ts
@@ -34,7 +34,10 @@ export async function GET(
       },
     });
 
-    if (!helpRequest) {
+    // Cross-tenant scoping: only the API key that created the request may read its messages.
+    // Use the same generic 404 response for both "not found" and "not yours" so the endpoint
+    // does not leak the existence of other tenants' request ids.
+    if (!helpRequest || helpRequest.apiKeyId !== authResult.apiKey.id) {
       return NextResponse.json(
         { error: "Request not found" },
         { status: 404 }

--- a/src/lib/adapters/openclaw.ts
+++ b/src/lib/adapters/openclaw.ts
@@ -32,6 +32,38 @@ export async function sendNotification(
   }
 }
 
+/**
+ * Compute the HMAC-SHA256 signature embedded in approve/deny action URLs.
+ * The signature binds the action and requestId so query-param callbacks
+ * cannot be forged or replayed across requests.
+ */
+export function signQueryAction(
+  webhookSecret: string,
+  action: "approve" | "deny",
+  requestId: string,
+): string {
+  return crypto
+    .createHmac("sha256", webhookSecret)
+    .update(`${action}:${requestId}`)
+    .digest("hex");
+}
+
+/** Constant-time verify the action URL signature. Returns false if the secret is empty. */
+export function verifyQueryActionSignature(
+  webhookSecret: string,
+  action: string,
+  requestId: string,
+  signature: string,
+): boolean {
+  if (!webhookSecret || !signature) return false;
+  if (action !== "approve" && action !== "deny") return false;
+  const expected = signQueryAction(webhookSecret, action, requestId);
+  const expectedBuf = Buffer.from(expected);
+  const sigBuf = Buffer.from(signature);
+  if (expectedBuf.length !== sigBuf.length) return false;
+  return crypto.timingSafeEqual(expectedBuf, sigBuf);
+}
+
 /** Send a notification with approval action URLs */
 export async function sendNotificationWithActions(
   webhookUrl: string,
@@ -44,14 +76,19 @@ export async function sendNotificationWithActions(
     message: string;
   },
 ): Promise<void> {
+  const approveSig = signQueryAction(webhookSecret, "approve", payload.requestId);
+  const denySig = signQueryAction(webhookSecret, "deny", payload.requestId);
+  const params = (action: "approve" | "deny", sig: string) =>
+    `?action=${action}&requestId=${encodeURIComponent(payload.requestId)}&sig=${sig}`;
+
   await sendNotification(webhookUrl, apiKey, webhookSecret, {
     type: "approval_required",
     requestId: payload.requestId,
     refCode: payload.refCode,
     message: payload.message,
     actions: {
-      approve: `${callbackBaseUrl}?action=approve&requestId=${payload.requestId}`,
-      deny: `${callbackBaseUrl}?action=deny&requestId=${payload.requestId}`,
+      approve: `${callbackBaseUrl}${params("approve", approveSig)}`,
+      deny: `${callbackBaseUrl}${params("deny", denySig)}`,
     },
     callbackUrl: callbackBaseUrl,
   });

--- a/website/pages/reference/changelog.mdx
+++ b/website/pages/reference/changelog.mdx
@@ -2,6 +2,12 @@ import { Callout } from 'nextra/components'
 
 # Changelog
 
+## v0.2.23 -- 2026-04-23
+
+### Security
+- **Cross-tenant message read closed.** `GET /api/v1/messages/:requestId` now verifies that the caller's API key created the help request before returning encrypted message blobs. Previously any valid API key could fetch the message history of any request whose id it knew. The endpoint returns the same generic `404 Request not found` for both unknown and not-yours ids so request id existence is not leaked across tenants (HEY-403)
+- **OpenClaw approve/deny URL forgery closed.** OpenClaw notification action URLs (`?action=approve|deny&requestId=...`) now require an HMAC-SHA256 `sig=` query parameter signed with the channel's webhook secret. The webhook handler verifies the signature in constant time before accepting the action. Previously the query-param fallback executed without verifying the secret, so anyone who learned a channel id and request id could approve or deny pending help requests for that expert. Existing channels keep working because the action URLs are generated server-side from the stored secret (HEY-403)
+
 ## v0.2.22 -- 2026-04-23
 
 ### Fixed

--- a/website/pages/security/api-security.mdx
+++ b/website/pages/security/api-security.mdx
@@ -19,13 +19,24 @@ Keys are validated using timing-safe comparison (resistant to timing attacks).
 |-----------|-----------------|
 | Submit help request | Client key (`hs_live_*`) |
 | Poll request status | Client key — only the submitting key |
+| Poll request messages | Client key — only the submitting key |
 | Send consumer message | Client key — only the submitting key |
 | Poll pending events | Client or expert key |
 | Send expert response | Expert key (`hs_exp_*`) |
 | Close a request | Expert key — only assigned expert |
 | Key management | Dashboard session only |
 
-**IDOR protection** — Clients can only access their own requests. Experts can only respond to requests assigned to their profile.
+**IDOR protection** — Every consumer endpoint that loads a `HelpRequest` by id verifies that the request was created by the API key on the call. Mismatches return a generic `404 Request not found` so the platform never confirms or denies the existence of another tenant's request id. This applies to `GET /api/v1/help/:requestId`, `GET /api/v1/messages/:requestId`, and the message send / event ack routes. Experts can only respond to requests routed to their profile.
+
+## Webhook adapters
+
+Webhook callbacks (`/api/adapters/{telegram|slack|openclaw}/{channelId}/webhook`) receive untrusted input. Each adapter authenticates the sender:
+
+- **Slack** — full HMAC-SHA256 signature (`x-slack-request-timestamp` + `x-slack-signature`) on every request.
+- **Telegram** — `x-telegram-bot-api-secret-token` shared with Telegram via `setWebhook`. The secret is rotated whenever the public URL changes.
+- **OpenClaw** — `X-OpenClaw-Signature` HMAC over the raw body for POST callbacks. Approve / deny **action URLs** included in notifications carry an additional `sig=` query parameter — an HMAC of `action:requestId` signed with the same channel secret. Action URLs without a valid `sig` are rejected with `403`.
+
+The OpenClaw query-action signature scheme means that even if an attacker learns a channel id and a request id from a leaked log or screenshot, they cannot forge an approve/deny call without the per-channel webhook secret.
 
 ## Rate limiting
 


### PR DESCRIPTION
## Summary

HEY-403 security review execution. Closes two CRITICAL findings on consumer + adapter surfaces; five Medium/Low findings filed as follow-ups (HEY-406 → HEY-410).

- **CRITICAL — IDOR on `GET /api/v1/messages/:requestId`.** Any caller with a valid API key could fetch another tenant's encrypted message blobs and metadata if they knew the request id. Now verifies `helpRequest.apiKeyId === authResult.apiKey.id` and returns a generic `404 Request not found` for both unknown and not-yours ids.
- **CRITICAL — OpenClaw approve/deny URL forgery.** Notification action URLs (`?action=approve&requestId=...`) accepted unauthenticated requests because the query-param fallback's only "auth" check was `if (!config.webhookSecret)` — always false once the channel is activated. Anyone who learned a channel id and request id could forge approve/deny calls and bypass the human gate. Now requires an HMAC-SHA256 `sig=` query parameter signed with the channel's webhook secret over `${action}:${requestId}`, verified in constant time. Existing channels keep working with no migration because action URLs are generated server-side from the stored secret.

Findings report with reproduction, impact, and fix per finding posted on [HEY-403](/HEY/issues/HEY-403).

## Changes

- `src/app/api/v1/messages/[requestId]/route.ts` — add ownership check.
- `src/lib/adapters/openclaw.ts` — add `signQueryAction` + `verifyQueryActionSignature`; embed `sig=` in action URLs.
- `src/app/api/adapters/openclaw/[id]/webhook/route.ts` — verify `sig` before accepting query-param actions; remove the no-op shared-secret check.
- `src/__tests__/api/v1-messages-idor.test.ts` (new) — cross-tenant 404, owner success, true 404, auth short-circuit.
- `src/__tests__/adapters/openclaw.test.ts` — `verifyQueryActionSignature` cases + `sendNotificationWithActions` `sig=` assertion.
- `website/pages/security/api-security.mdx` — documents IDOR scoping rule and OpenClaw action-URL signature scheme.
- `website/pages/reference/changelog.mdx` — `v0.2.23` security entry.
- `package.json`, `cli/package.json`, `packages/consumer-sdk/package.json` — version bump to `0.2.23`.

## Test plan

- [x] `pnpm test` — 30 files, 329 tests passing on this branch.
- [x] `pnpm lint` — 0 errors, 77 pre-existing warnings (none introduced).
- [x] Static analysis: 93 routes under `src/app/api/**` enumerated; auth wrapper, validation, encryption boundary, scoping, and logging audited.
- [x] Dynamic probes against `https://testhost-a87612gsja.heysummon.online` only (in-scope test host); `X-HeySummon-Security-Probe: hey-403` on every request. No DoS, no destructive actions, no probes outside the authorized host.
- [ ] Reviewer: please double-check the constant-time comparison + length guard in `verifyQueryActionSignature` and confirm the OpenClaw notification action URL contract is acceptable to existing OpenClaw integrations.
- [ ] Reviewer: confirm whether the `HelpRequest.apiKeyId` field is the canonical owner pointer for cross-tenant scoping (vs. `expertId`) — both work, but `apiKeyId` keeps the message-history endpoint symmetric with `/api/v1/help/:requestId`.

## Follow-ups (filed under HEY-403)

- [HEY-406](/HEY/issues/HEY-406) — Encrypt `ExpertChannel.config` and `Integration.config` secrets at rest (High)
- [HEY-407](/HEY/issues/HEY-407) — Encrypt `HelpRequest.response` and `phoneCallResponse` at rest (Medium)
- [HEY-408](/HEY/issues/HEY-408) — Rate-limit and audit GDPR data export endpoints (Low)
- [HEY-409](/HEY/issues/HEY-409) — Move setup token off URL path; consume on first fetch (Low)
- [HEY-410](/HEY/issues/HEY-410) — Validate admin-controlled URL fields (Low)

Closes [HEY-404](/HEY/issues/HEY-404). Linked to [HEY-403](/HEY/issues/HEY-403).
