### PR TITLE
fix(claude-code): converge plugin and curl install paths (HEY-450)

### DIFF
--- a/skills/claudecode/heysummon/skills/setup/SKILL.md
+++ b/skills/claudecode/heysummon/skills/setup/SKILL.md
@@ -15,7 +15,7 @@ Set up HeySummon using the provided setup URL from your expert's dashboard.
 2. Build the command endpoint URL by replacing `/setup/` with `/api/v1/setup/` and appending `/command` in the URL
 3. Fetch that JSON endpoint with a GET request
 4. The response contains an `installCommand` field -- execute it in the current project directory using bash
-5. Verify the `.env` file was created in the skill directory with the correct credentials
+5. Verify the `.env` file was created at `.claude/skills/heysummon/.env` (canonical, project-local) with the correct credentials
 6. Confirm the setup was successful
 
 ## Example
@@ -30,4 +30,5 @@ curl -sf "https://example.com/api/v1/setup/st_abc123/command" | jq -r '.installC
 
 - The setup URL is valid for 24 hours
 - The install command downloads skill scripts, writes credentials to `.env`, and verifies the connection
+- The canonical `.env` location is **`<project>/.claude/skills/heysummon/.env`** regardless of whether the marketplace plugin is installed. The plugin's bundled scripts read `.env` from the project-local path, so re-running setup is always safe and never produces a divergent second config.
 - After setup, you can use HeySummon by saying "hey summon <expert-name> <question>"

--- a/skills/heysummon/scripts/_lib.sh
+++ b/skills/heysummon/scripts/_lib.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# HeySummon — shared helpers for skill scripts
+#
+# Resolves the canonical .env path. Sourced by ask.sh, setup.sh, add-expert.sh,
+# list-experts.sh, check-status.sh.
+#
+# Read priority:
+#   1. $HEYSUMMON_ENV_FILE if explicitly set and exists
+#   2. $SKILL_DIR/.env                              (curl-only / project-local install)
+#   3. $PWD/.claude/skills/heysummon/.env           (Claude Code plugin runtime)
+#
+# Write priority (for setup.sh / add-expert.sh):
+#   1. $HEYSUMMON_ENV_FILE if explicitly set
+#   2. $SKILL_DIR/.env if $SKILL_DIR is writable
+#   3. $PWD/.claude/skills/heysummon/.env (created if missing)
+
+heysummon_resolve_env_read() {
+  if [ -n "${HEYSUMMON_ENV_FILE:-}" ] && [ -f "$HEYSUMMON_ENV_FILE" ]; then
+    printf '%s\n' "$HEYSUMMON_ENV_FILE"
+    return 0
+  fi
+  if [ -n "${SKILL_DIR:-}" ] && [ -f "$SKILL_DIR/.env" ]; then
+    printf '%s\n' "$SKILL_DIR/.env"
+    return 0
+  fi
+  local project_env="$PWD/.claude/skills/heysummon/.env"
+  if [ -f "$project_env" ]; then
+    printf '%s\n' "$project_env"
+    return 0
+  fi
+  return 1
+}
+
+heysummon_load_env() {
+  local env_file
+  if env_file="$(heysummon_resolve_env_read)"; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$env_file"
+    set +a
+    HEYSUMMON_ENV_FILE="$env_file"
+    export HEYSUMMON_ENV_FILE
+  fi
+}
+
+heysummon_resolve_env_write() {
+  if [ -n "${HEYSUMMON_ENV_FILE:-}" ]; then
+    printf '%s\n' "$HEYSUMMON_ENV_FILE"
+    return 0
+  fi
+  if [ -n "${SKILL_DIR:-}" ] && [ -w "$SKILL_DIR" ]; then
+    printf '%s\n' "$SKILL_DIR/.env"
+    return 0
+  fi
+  local project_dir="$PWD/.claude/skills/heysummon"
+  mkdir -p "$project_dir" 2>/dev/null || true
+  printf '%s\n' "$project_dir/.env"
+}
+
+heysummon_load_env

--- a/skills/heysummon/scripts/add-expert.sh
+++ b/skills/heysummon/scripts/add-expert.sh
@@ -5,12 +5,11 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/sdk.sh"
-
-[ -f "$SKILL_DIR/.env" ] && set -a && source "$SKILL_DIR/.env" && set +a
+source "$SCRIPT_DIR/_lib.sh"
 
 # Persist HEYSUMMON_BASE_URL to .env if provided as env prefix
 if [ -n "$HEYSUMMON_BASE_URL" ]; then
-  ENV_FILE="$SKILL_DIR/.env"
+  ENV_FILE="$(heysummon_resolve_env_write)"
   if [ ! -f "$ENV_FILE" ] || ! grep -q "^HEYSUMMON_BASE_URL=" "$ENV_FILE" 2>/dev/null; then
     echo "HEYSUMMON_BASE_URL=$HEYSUMMON_BASE_URL" >> "$ENV_FILE"
   fi

--- a/skills/heysummon/scripts/ask.sh
+++ b/skills/heysummon/scripts/ask.sh
@@ -9,9 +9,7 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/sdk.sh"
-
-# Load .env
-[ -f "$SKILL_DIR/.env" ] && set -a && source "$SKILL_DIR/.env" && set +a
+source "$SCRIPT_DIR/_lib.sh"
 
 QUESTION="$1"
 CONTEXT="${2:-}"

--- a/skills/heysummon/scripts/check-status.sh
+++ b/skills/heysummon/scripts/check-status.sh
@@ -5,8 +5,7 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/sdk.sh"
-
-[ -f "$SKILL_DIR/.env" ] && set -a && source "$SKILL_DIR/.env" && set +a
+source "$SCRIPT_DIR/_lib.sh"
 
 if [ -z "$1" ]; then
   echo "Usage: check-status.sh <refCode|requestId>"

--- a/skills/heysummon/scripts/list-experts.sh
+++ b/skills/heysummon/scripts/list-experts.sh
@@ -4,8 +4,7 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/sdk.sh"
-
-[ -f "$SKILL_DIR/.env" ] && set -a && source "$SKILL_DIR/.env" && set +a
+source "$SCRIPT_DIR/_lib.sh"
 
 export HEYSUMMON_EXPERTS_FILE="${HEYSUMMON_EXPERTS_FILE:-$HOME/.heysummon/experts.json}"
 

--- a/skills/heysummon/scripts/setup.sh
+++ b/skills/heysummon/scripts/setup.sh
@@ -5,7 +5,8 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/sdk.sh"
-ENV_FILE="$SKILL_DIR/.env"
+source "$SCRIPT_DIR/_lib.sh"
+ENV_FILE="$(heysummon_resolve_env_write)"
 
 echo ""
 echo "HeySummon — Skill Setup"

--- a/website/pages/clients/claude-code.mdx
+++ b/website/pages/clients/claude-code.mdx
@@ -78,16 +78,36 @@ agent keeps working. Notifications expire after 7 days if nobody acks. See
 [Consumer API Reference -> Notification Mode](/consumer/api-reference#notification-mode-notify)
 for the full contract.
 
-## Skill Location
+## Canonical install location
 
-When installed via the marketplace, the plugin lives in Claude Code's plugin cache. When installed manually, the skill files are at:
+Regardless of which entry point you used (marketplace plugin, curl install, or interactive setup), the skill's per-project credentials live at a single canonical location:
 
 ```
-.claude/skills/heysummon/
+<project-root>/.claude/skills/heysummon/.env
+```
+
+This is the only place credentials are written and the first place the bundled scripts look.
+
+**Why project-local?** Per-expert API keys are project-scoped (one project may talk to a different HeySummon instance, or a different expert, than another). `.claude/` is already the convention for Claude Code's project-local configuration. The plugin cache (`~/.claude/plugins/...`) is a Claude Code internal — read-only from the agent's POV and not appropriate for per-project secrets.
+
+The bundled scripts (`ask.sh`, `setup.sh`, `add-expert.sh`, etc.) resolve the `.env` file in this priority order at runtime:
+
+1. `$HEYSUMMON_ENV_FILE` if explicitly set
+2. `$SKILL_DIR/.env` (when scripts are run from the project-local skill folder)
+3. `$PWD/.claude/skills/heysummon/.env` (when scripts are run from the plugin cache)
+
+This means a workspace where the plugin is installed and a workspace where you ran the curl install both end up reading and writing the same project-local `.env`. Re-running setup via either entry point is a no-op or a clean overwrite — never a divergent second config.
+
+## Skill files
+
+```
+<project-root>/.claude/skills/heysummon/
   SKILL.md           # Instructions for Claude
-  scripts/           # ask.sh, setup.sh, etc.
-  .env               # API key and configuration
+  scripts/           # ask.sh, setup.sh, _lib.sh, etc.
+  .env               # API key and configuration (canonical, project-local)
 ```
+
+When installed via the marketplace plugin, the `SKILL.md` and `scripts/` may also exist inside Claude Code's plugin cache. The scripts there will still resolve `.env` from the project-local path above — so credentials never leak into the plugin cache and never diverge between cache and project copies.
 
 ## Configuration
 

--- a/website/pages/reference/changelog.mdx
+++ b/website/pages/reference/changelog.mdx
@@ -4,6 +4,9 @@ import { Callout } from 'nextra/components'
 
 ## v0.2.24 -- Unreleased
 
+### Fixed
+- **Claude Code plugin/curl install convergence (HEY-450).** Bundled skill scripts (`ask.sh`, `setup.sh`, `add-expert.sh`, `list-experts.sh`, `check-status.sh`) now share a single `_lib.sh` helper that resolves the canonical `.env` from `$HEYSUMMON_ENV_FILE`, then `$SKILL_DIR/.env`, then `$PWD/.claude/skills/heysummon/.env`. Previously, when scripts were resolved from Claude Code's plugin cache, `$SKILL_DIR/.env` did not exist there and the scripts failed with `HEYSUMMON_API_KEY not set` even when the project-local `.env` was present. The plugin and the curl one-liner now both read and write the same project-local `.env` at `<project>/.claude/skills/heysummon/.env`, eliminating the dual-config divergence. Documented as the canonical install location in `clients/claude-code.mdx`. No data migration needed; users who installed via plugin only and never re-ran setup should run `/heysummon:setup <link>` once to write the project-local `.env`.
+
 ### Added
 - **Install round-trip probe (HEY-445).** New `POST /api/v1/setup/verify-roundtrip` endpoint that creates a synthetic `probe: true` HelpRequest, resolves the expert's active notification channel, and returns `{ ok, expertName, channelType }` — without dispatching any Telegram/Slack/OpenClaw fan-out. Probe rows are filtered out of every dashboard, events, search, and channel-adapter list query through a new `src/lib/help-request-scope.ts` helper, so they never leak into the expert's inbox, counts, or analytics. Distinct error codes (`auth`, `expert_disabled`, `no_channel`, `encryption_unconfigured`, `internal`) let the install script branch on the failure stage. Adds a Prisma migration for `HelpRequest.probe Boolean @default(false)` (existing rows backfill to `false`). Workstream B1 of the install rebuild — the install script (B2) calls this endpoint to prove a real round-trip before declaring success.
 


### PR DESCRIPTION
## Summary

- Adds `skills/heysummon/scripts/_lib.sh` with `heysummon_resolve_env_read` / `heysummon_resolve_env_write` that resolve a single canonical `.env` (priority: `$HEYSUMMON_ENV_FILE` → `$SKILL_DIR/.env` → `$PWD/.claude/skills/heysummon/.env`).
- Refactors `ask.sh`, `setup.sh`, `add-expert.sh`, `list-experts.sh`, and `check-status.sh` to source `_lib.sh` instead of inlining the env-load expression.
- Removes the dual-config divergence between the marketplace plugin (which resolves the skill from `~/.claude/plugins/...`) and the curl install (which writes to `<project>/.claude/skills/heysummon/`). Both entry points now read the same project-local `.env`.
- Documents canonical location in `website/pages/clients/claude-code.mdx` and `skills/claudecode/heysummon/skills/setup/SKILL.md`.
- Adds changelog entry under `v0.2.24 -- Unreleased` in `website/pages/reference/changelog.mdx`.

Refs [HEY-450](https://heysummon.ai/HEY/issues/HEY-450) and HEY-440 (Workstream C copy convergence).

## Test plan

- [ ] Manual: install via marketplace plugin, then run `bash skills/heysummon/scripts/ask.sh "ping"` from a project with `.claude/skills/heysummon/.env` — confirm it loads credentials and submits a request.
- [ ] Manual: run curl install in a fresh repo, confirm `.env` lands at `.claude/skills/heysummon/.env`, then `ask.sh` works.
- [ ] Re-run `setup.sh` with both plugin- and curl-installed states; confirm both write back to the same `.env`.
- [ ] Existing snapshot/unit tests stay green (no copy generation changes; coordinated with HEY-440).