### PR TITLE
fix(cli): use execFileSync for rsync in copyFromSourceDir (HEY-466)

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import * as p from "@clack/prompts";
 import {
   getHeysummonDir,
@@ -27,8 +27,16 @@ function copyFromSourceDir(sourceDir: string, destDir: string): void {
   if (!fs.existsSync(path.join(absSource, "package.json"))) {
     throw new Error(`No package.json in source directory: ${absSource}`);
   }
-  execSync(
-    `rsync -a --exclude=node_modules --exclude=.next --exclude=.git "${absSource}/" "${destDir}/"`,
+  execFileSync(
+    "rsync",
+    [
+      "-a",
+      "--exclude=node_modules",
+      "--exclude=.next",
+      "--exclude=.git",
+      `${absSource}/`,
+      `${destDir}/`,
+    ],
     { stdio: "pipe" }
   );
 }


### PR DESCRIPTION
## Summary

Closes [HEY-466](/HEY/issues/HEY-466). Fixes CodeQL alert [#35](https://github.com/thomasansems/heysummon/security/code-scanning/35) (`js/shell-command-injection-from-environment`).

`copyFromSourceDir` in `cli/src/commands/init.ts` was building a shell command string with user-provided `absSource` and `destDir` paths interpolated in. Switched to `execFileSync` with an args array so rsync receives the paths directly without shell interpretation.

## Changes

- `cli/src/commands/init.ts`: replace `execSync` shell-string call with `execFileSync(\"rsync\", [...])`. `execSync` was only used in this one spot, so the import was swapped to `execFileSync`.

## Test plan

- [x] `tsc --noEmit` passes for the cli package.
- [ ] Manual: `heysummon init --from-source \"/tmp/path with spaces/heysummon\"` copies the source tree correctly (paths with spaces no longer rely on shell quoting).
- [ ] CodeQL alert #35 auto-closes on next analysis run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)