### PR TITLE
fix(security): URL-parse detectMethod() + drop broken codeql query-filters (HEY-467)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,16 +5,3 @@ paths-ignore:
   # CLI output functions are not logging sensitive data;
   # CodeQL traces process.env → function calls incorrectly
   - cli/src/lib/ui.ts
-
-query-filters:
-  # HMAC-SHA256 is used as a keyed MAC for database index lookup,
-  # NOT for password hashing. Passwords use bcrypt (auth-config.ts).
-  # API keys are high-entropy random tokens (128-bit).
-  - exclude:
-      id: js/insufficient-password-hash
-      path: src/lib/api-key-auth.ts
-  # detectMethod() classifies tunnel type from trusted input
-  # (process.env or tailscale CLI output), not for security sanitization
-  - exclude:
-      id: js/incomplete-url-substring-sanitization
-      path: src/app/api/admin/tunnel/status/route.ts

--- a/src/__tests__/api/tunnel-detect-method.test.ts
+++ b/src/__tests__/api/tunnel-detect-method.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUser: vi.fn(),
+}));
+
+import { detectMethod } from "@/app/api/admin/tunnel/status/route";
+
+describe("detectMethod", () => {
+  it("classifies tailscale apex hostnames", () => {
+    expect(detectMethod("https://my-tailnet.ts.net")).toBe("tailscale");
+  });
+
+  it("classifies tailscale subdomain hostnames", () => {
+    expect(detectMethod("https://my-host.tailnet-cafe.ts.net")).toBe("tailscale");
+  });
+
+  it("classifies cloudflared trycloudflare.com hostnames", () => {
+    expect(detectMethod("https://random.trycloudflare.com")).toBe("cloudflared");
+  });
+
+  it("classifies custom hostnames", () => {
+    expect(detectMethod("https://heysummon.example.com")).toBe("custom");
+  });
+
+  it("returns custom for malformed URLs", () => {
+    expect(detectMethod("not a url")).toBe("custom");
+  });
+
+  it("rejects attacker URLs that put .ts.net in the path", () => {
+    expect(detectMethod("https://evil.com/.ts.net")).toBe("custom");
+  });
+
+  it("rejects attacker URLs that put trycloudflare.com in the query string", () => {
+    expect(detectMethod("https://example.com?host=trycloudflare.com")).toBe("custom");
+  });
+});

--- a/src/app/api/admin/tunnel/status/route.ts
+++ b/src/app/api/admin/tunnel/status/route.ts
@@ -13,9 +13,16 @@ function getTailscaleHostname(): string | null {
   return null;
 }
 
-function detectMethod(url: string): "tailscale" | "cloudflared" | "custom" {
-  if (url.includes(".ts.net")) return "tailscale";
-  if (url.includes("trycloudflare.com") || url.includes(".cloudflare")) return "cloudflared";
+export function detectMethod(url: string): "tailscale" | "cloudflared" | "custom" {
+  let host: string;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return "custom";
+  }
+  if (host.endsWith(".ts.net")) return "tailscale";
+  if (host === "trycloudflare.com" || host.endsWith(".trycloudflare.com")) return "cloudflared";
+  if (host.endsWith(".cloudflare.com") || host.endsWith(".cloudflareaccess.com")) return "cloudflared";
   return "custom";
 }
 


### PR DESCRIPTION
## Summary

Closes [HEY-467](/HEY/issues/HEY-467) — addresses CodeQL alerts [#29](https://github.com/thomasansems/heysummon/security/code-scanning/29) and [#30](https://github.com/thomasansems/heysummon/security/code-scanning/30) (`js/incomplete-url-substring-sanitization`).

- Rewrite `detectMethod()` in `src/app/api/admin/tunnel/status/route.ts` to parse the URL with the `URL` constructor and match the **hostname** by suffix, so inputs like `https://evil.com/.ts.net` no longer classify as Tailscale.
- Export the function so it is unit-testable, and add a Vitest suite covering the cases from the ticket (tailscale apex/subdomain, cloudflared, custom, malformed URL, two attacker-style inputs).
- Remove the `query-filters:` block from `.github/codeql/codeql-config.yml`. It used an unsupported `path:` field on `exclude` (CodeQL only filters on query metadata), so it never took effect — alerts re-surfaced on every analysis. `paths-ignore` stays.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/api/tunnel-detect-method.test.ts` — 7 / 7 passing
- [x] `pnpm exec eslint` on changed files — clean
- [ ] Next CodeQL run on this branch closes alerts #29 and #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)