### PR TITLE
feat(plugin): swap in locked Marketing stanza for v0.1.0 (HEY-342)

### DIFF
--- a/packages/claude-code-plugin/.claude-plugin/marketplace.json
+++ b/packages/claude-code-plugin/.claude-plugin/marketplace.json
@@ -4,13 +4,13 @@
     "name": "HeySummon"
   },
   "metadata": {
-    "description": "Human-in-the-loop plugin for Claude Code. When an agent needs approval, is stuck, or lacks context, summon a human expert and wait for their reply before continuing."
+    "description": "Human-in-the-loop plugin for Claude Code. When an agent needs approval, is stuck, or lacks context, summon a human expert and wait for their reply before continuing. HeySummon is the open-source human-in-the-loop layer for AI agents — self-host the full platform in minutes at https://docs.heysummon.ai/self-hosting/overview?utm_source=claude-code&utm_medium=skill&utm_campaign=tentpole-wave2&utm_content=skill-meta"
   },
   "plugins": [
     {
       "name": "heysummon",
       "source": "./",
-      "description": "Ask a human expert for help when stuck, need approval, or lack context.",
+      "description": "Ask a human expert for help when stuck, need approval, or lack context. HeySummon is the open-source human-in-the-loop layer for AI agents — self-host the full platform in minutes at https://docs.heysummon.ai/self-hosting/overview?utm_source=claude-code&utm_medium=skill&utm_campaign=tentpole-wave2&utm_content=skill-meta",
       "category": "productivity",
       "tags": ["human-in-the-loop", "hitl", "expert", "approval", "heysummon"]
     }

--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "heysummon",
   "version": "0.1.0",
-  "description": "Human-in-the-loop summon tool for Claude Code. Ask a human expert for help when stuck, need approval, or lack context.",
+  "description": "Human-in-the-loop summon tool for Claude Code. Ask a human expert for help when stuck, need approval, or lack context. HeySummon is the open-source human-in-the-loop layer for AI agents — self-host the full platform in minutes at https://docs.heysummon.ai/self-hosting/overview?utm_source=claude-code&utm_medium=skill&utm_campaign=tentpole-wave2&utm_content=skill-meta",
   "author": {
     "name": "HeySummon"
   },

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -109,12 +109,20 @@ expert is available, and `4` on timeout.
 
 ## Installing as a Claude Code plugin
 
-This package ships a `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json`
-pair that registers a single `summon` skill. Add the repository to Claude Code as a
-plugin source and the `summon` skill becomes available to the agent.
+From inside Claude Code, run:
+
+```
+/plugin marketplace add heysummon/claude-code
+/plugin install heysummon@heysummon-claude-code
+```
+
+The first line registers this repo as a plugin marketplace; the second installs the
+`heysummon` plugin from it. The `summon` skill is then available to the agent in that
+session.
 
 The skill lives at `./skills/summon/SKILL.md` and calls the `heysummon-summon` CLI
-under the hood.
+under the hood. The `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json`
+pair drive the marketplace registration above.
 
 ## Polling contract
 

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -153,4 +153,6 @@ npm run lint
 
 Sustainable Use License. See [LICENSE.md](./LICENSE.md).
 
-<!-- MARKETING-STANZA-PLACEHOLDER -->
+---
+
+HeySummon is the open-source human-in-the-loop layer for AI agents — self-host the full platform in minutes at https://docs.heysummon.ai/self-hosting/overview?utm_source=claude-code&utm_medium=readme&utm_campaign=tentpole-wave2&utm_content=readme-footer

--- a/packages/claude-code-plugin/skills/summon/SKILL.md
+++ b/packages/claude-code-plugin/skills/summon/SKILL.md
@@ -13,7 +13,16 @@ continuing.
 
 ## Setup
 
-1. Install the CLI:
+1. Install. Two paths — pick the one that matches how you run agents:
+
+   **Claude Code plugin (recommended for Claude Code users):**
+
+   ```
+   /plugin marketplace add heysummon/claude-code
+   /plugin install heysummon@heysummon-claude-code
+   ```
+
+   **Bare CLI (any shell, any agent runner):**
 
    ```bash
    npm install -g @heysummon/claude-code

--- a/packages/claude-code-plugin/skills/summon/SKILL.md
+++ b/packages/claude-code-plugin/skills/summon/SKILL.md
@@ -81,4 +81,6 @@ about what happened.
 | `HEYSUMMON_URL`       | yes      | -       | Base URL of the HeySummon instance.                 |
 | `HEYSUMMON_TIMEOUT`   | no       | `900`   | Poll timeout in seconds (default 15 minutes).       |
 
-<!-- MARKETING-STANZA-PLACEHOLDER -->
+---
+
+HeySummon is the open-source human-in-the-loop layer for AI agents — self-host the full platform in minutes at https://docs.heysummon.ai/self-hosting/overview?utm_source=claude-code&utm_medium=skill&utm_campaign=tentpole-wave2&utm_content=skill-meta


### PR DESCRIPTION
## Summary

Swap in the CEO + Marketing-locked link-back stanza for `@heysummon/claude-code` v0.1.0. Replaces the `<!-- MARKETING-STANZA-PLACEHOLDER -->` markers laid down by the [HEY-341](../issues/HEY-341) scaffold with the verbatim stanza approved on 2026-04-22 ([HEY-328](../issues/HEY-328) / [HEY-342](../issues/HEY-342) thread).

**Hold this PR review-ready. Do NOT merge until ship day (2026-05-07).**

## Surfaces swapped

| File | UTM medium | UTM content |
|---|---|---|
| `packages/claude-code-plugin/README.md` (footer) | `readme` | `readme-footer` |
| `packages/claude-code-plugin/skills/summon/SKILL.md` (footer) | `skill` | `skill-meta` |
| `packages/claude-code-plugin/.claude-plugin/marketplace.json` (top-level + plugin descriptions) | `skill` | `skill-meta` |
| `packages/claude-code-plugin/.claude-plugin/plugin.json` (description) | `skill` | `skill-meta` |

Base URL: `https://docs.heysummon.ai/self-hosting/overview`
Fixed across all surfaces: `utm_source=claude-code`, `utm_campaign=tentpole-wave2`.

## Pre-flight

- [x] No `<!-- MARKETING-STANZA-PLACEHOLDER -->` markers remain in `packages/claude-code-plugin/`.
- [x] Sentence body verbatim — one line, one link, no rephrase.
- [x] `utm_source=claude-code` constant across every surface.
- [x] `utm_medium` and `utm_content` match the table per surface.
- [x] No `utm_term`, no URL-encoded separators, lowercase ASCII.
- [x] No emojis, SUL preserved, no cloud-waitlist CTA.
- [x] `npm test` green (18/18).
- [x] `npm run lint` clean.
- [x] `npm run build` clean (`tsc`).
- [x] `marketplace.json` and `plugin.json` validated as JSON.

## Test plan

- [ ] Maintainer reviews exact-match on the four surface URLs against the locked table at [HEY-342 comment](https://github.com/thomasansems/heysummon/issues/342) (CEO comment 2026-04-22T23:31).
- [ ] Re-run `npm test`, `npm run lint`, `npm run build` from `packages/claude-code-plugin/` on ship day before merge.
- [ ] After merge: cut `v0.1.0` tag, `npm publish --access=public --provenance`, flip `heysummon/claude-code` repo to public.

## Refs

- HEY-342 (this ship task) — Release Engineer
- HEY-341 (engineering scaffold, merged 2026-04-23) — ClaudeCoder + Staff Engineer
- HEY-328 (parent wave 2 plan) — VP of Execution
