### PR TITLE
feat(docs): wire Umami analytics on docs.heysummon.ai (HEY-505)

### DIFF
--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -86,6 +86,9 @@ const config: DocsThemeConfig = {
     const description = frontMatter.description || DEFAULT_DESCRIPTION
     const url = SITE_URL + asPath
 
+    const umamiUrl = process.env.NEXT_PUBLIC_UMAMI_URL
+    const umamiWebsiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID
+
     return (
       <>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -105,6 +108,14 @@ const config: DocsThemeConfig = {
         <link rel="icon" href="/favicon-96x96.png" sizes="96x96" type="image/png" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <link rel="manifest" href="/site.webmanifest" />
+        {umamiUrl && umamiWebsiteId && (
+          <script
+            async
+            defer
+            data-website-id={umamiWebsiteId}
+            src={`${umamiUrl}/script.js`}
+          />
+        )}
       </>
     )
   },


### PR DESCRIPTION
## Summary
- Add Umami analytics script to the Nextra docs theme `head` so `docs.heysummon.ai` captures pageviews + UTM query params for the Wave 2 link-back stanzas.
- Activated only when `NEXT_PUBLIC_UMAMI_URL` and `NEXT_PUBLIC_UMAMI_WEBSITE_ID` are set in the deploy env; otherwise the script tag is omitted, so unconfigured environments stay unchanged.
- Mirrors the existing pattern in `landingspage/index.html` so both surfaces share one Umami project once env vars are provisioned.

## Why
- CEO's 2026-04-22 URL correction moved the Wave 2 link-back target from `heysummon.ai/self-hosting` to `docs.heysummon.ai/self-hosting/overview`. The docs subdomain is now the **only** measurement surface for pole #1 week-2 (2026-05-21).
- Live check on 2026-05-01 found zero analytics on `docs.heysummon.ai` and unresolved `%VITE_UMAMI_*%` placeholders on `heysummon.ai` — both surfaces are dark today.
- HEY-505 deadline 2026-05-05; final-deadline-as-blocker 2026-05-07 publish gate per HEY-328.

## Test plan
- [x] Provision Umami instance (or confirm existing) and set `NEXT_PUBLIC_UMAMI_URL` + `NEXT_PUBLIC_UMAMI_WEBSITE_ID` in Vercel for `docs.heysummon.ai`.
- [ ] Also set `VITE_UMAMI_URL` + `VITE_UMAMI_WEBSITE_ID` for `heysummon.ai` so both surfaces share attribution (separate from this PR but unblocks HEY-505 verification).
- [ ] Hit `https://docs.heysummon.ai/self-hosting/overview?utm_source=claude-code&utm_medium=readme&utm_campaign=tentpole-wave2&utm_content=readme-footer` and confirm a pageview with all UTM params lands in the Umami dashboard.
- [ ] Post screenshot/dashboard link on HEY-505 and close `done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)