### PR TITLE
feat(landingspage): Privacy, Terms, Contact links in footer (HEY-514)

### DIFF
--- a/landingspage/public/privacy.html
+++ b/landingspage/public/privacy.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy Policy — HeySummon</title>
+    <meta name="description" content="HeySummon privacy policy: what we collect on the waitlist, how we store it, and how to request deletion." />
+    <meta name="robots" content="index,follow" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Joti+One&display=swap" rel="stylesheet">
+    <style>
+      :root {
+        --bg-deep: #0f1410;
+        --bg-card: #1e2420;
+        --text-heading: #e8e4df;
+        --text-body: #9a958e;
+        --text-muted: #6b6660;
+        --primary: #ff826d;
+        --border: rgba(255, 255, 255, 0.1);
+      }
+      * { box-sizing: border-box; }
+      html { scroll-behavior: smooth; }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-body);
+        font-family: 'DM Sans', system-ui, sans-serif;
+        line-height: 1.7;
+        -webkit-font-smoothing: antialiased;
+      }
+      a { color: var(--primary); text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      header {
+        border-bottom: 1px solid var(--border);
+        padding: 1.5rem 2rem;
+      }
+      header .inner {
+        max-width: 64rem;
+        margin: 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+      header img { height: 2rem; width: auto; }
+      header nav a {
+        color: var(--text-body);
+        margin-left: 1.25rem;
+        font-size: 0.875rem;
+      }
+      header nav a:hover { color: var(--text-heading); text-decoration: none; }
+      main {
+        max-width: 48rem;
+        margin: 0 auto;
+        padding: 3rem 2rem 5rem;
+      }
+      h1, h2, h3 { color: var(--text-heading); line-height: 1.25; }
+      h1 { font-size: 2.25rem; margin: 0 0 0.5rem; }
+      h2 { font-size: 1.375rem; margin: 2.5rem 0 0.75rem; }
+      h3 { font-size: 1.05rem; margin: 1.75rem 0 0.5rem; }
+      p, ul { margin: 0 0 1rem; }
+      ul { padding-left: 1.25rem; }
+      li { margin-bottom: 0.35rem; }
+      .meta { color: var(--text-muted); font-size: 0.875rem; margin-bottom: 2rem; }
+      footer {
+        border-top: 1px solid var(--border);
+        padding: 2rem;
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 0.875rem;
+      }
+      footer a { color: var(--text-body); margin: 0 0.5rem; }
+      footer a:hover { color: var(--text-heading); text-decoration: none; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="inner">
+        <a href="/"><img src="/logo.png" alt="HeySummon" /></a>
+        <nav>
+          <a href="/">Home</a>
+          <a href="https://docs.heysummon.ai">Docs</a>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <h1>Privacy Policy</h1>
+      <p class="meta">Last updated: 1 May 2026</p>
+
+      <p>
+        HeySummon ("we", "us") is an open-source human-in-the-loop platform for AI agents.
+        This page explains what personal data we collect when you visit
+        <a href="https://heysummon.ai">heysummon.ai</a> or join our launch waitlist at
+        <a href="https://cloud.heysummon.ai">cloud.heysummon.ai</a>, how we use it, and how
+        you can request deletion. The self-hosted product itself runs on infrastructure
+        you control and does not send your operational data to us.
+      </p>
+
+      <h2>Who is the data controller?</h2>
+      <p>
+        HeySummon, operated by Thomas Ansems (Netherlands). For privacy questions or
+        requests, contact <a href="mailto:hello@heysummon.ai">hello@heysummon.ai</a>.
+      </p>
+
+      <h2>What we collect</h2>
+
+      <h3>Waitlist email collection</h3>
+      <p>
+        When you sign up for the launch waitlist on <code>cloud.heysummon.ai</code> we
+        collect:
+      </p>
+      <ul>
+        <li>Your email address.</li>
+        <li>The timestamp of your sign-up.</li>
+        <li>The referring source if it is shared by your browser (for example a UTM tag).</li>
+      </ul>
+      <p>
+        We use this only to (a) email you when the hosted product opens for early access,
+        and (b) send at most a handful of launch updates. We do not sell, rent, or share
+        waitlist emails with third parties for their own marketing.
+      </p>
+
+      <h3>Privacy-friendly analytics</h3>
+      <p>
+        We use <a href="https://umami.is" target="_blank" rel="noopener">Umami</a>,
+        a cookie-less, GDPR-compliant analytics tool, to count page views and
+        understand which sections of the site are useful. Umami does not use cookies,
+        does not fingerprint visitors, and does not collect personal data. IP addresses
+        are hashed and discarded.
+      </p>
+
+      <h3>What we do NOT collect on the marketing site</h3>
+      <ul>
+        <li>No advertising cookies.</li>
+        <li>No third-party tracking scripts (Google Analytics, Meta Pixel, etc.).</li>
+        <li>No cross-site profiling.</li>
+      </ul>
+
+      <h2>How long we keep your data</h2>
+      <ul>
+        <li>
+          <strong>Waitlist emails:</strong> kept until the hosted product is open and you
+          have either (a) accepted an invite and converted into a registered account, or
+          (b) explicitly unsubscribed, or (c) been on the list for more than 24 months
+          without sign-in, in which case the entry is deleted.
+        </li>
+        <li>
+          <strong>Analytics events:</strong> aggregated and retained for up to 12 months,
+          then rolled up or deleted.
+        </li>
+      </ul>
+
+      <h2>How to request deletion or access</h2>
+      <p>
+        Under GDPR (EU/EEA) and CCPA (California) you have the right to access, correct,
+        export, or delete the personal data we hold about you. To exercise any of these
+        rights, email <a href="mailto:hello@heysummon.ai">hello@heysummon.ai</a> from the
+        address you used to sign up, or include enough information that we can verify
+        your identity. We will respond within 30 days.
+      </p>
+      <p>
+        You can also unsubscribe from any waitlist or launch email by using the
+        unsubscribe link in the email itself; that automatically removes your address
+        from the list.
+      </p>
+
+      <h2>Where your data is stored</h2>
+      <p>
+        Waitlist data is hosted by Vercel (United States, with EU data-processing
+        addendum). Email delivery uses our transactional email provider. Both providers
+        are bound by data-processing agreements that prohibit them from using your data
+        for their own purposes.
+      </p>
+
+      <h2>Self-hosted HeySummon</h2>
+      <p>
+        If you run HeySummon yourself (via Docker or <code>npx @heysummon/app</code>),
+        you are the data controller for any data your deployment processes. We never
+        receive a copy of your help requests, expert messages, API keys, or
+        encryption keys. End-to-end encryption is on by default, and the platform
+        does not store plaintext for encrypted requests.
+      </p>
+
+      <h2>Children</h2>
+      <p>
+        HeySummon is a developer tool and is not directed at children under 16. We do
+        not knowingly collect personal data from children.
+      </p>
+
+      <h2>Changes to this policy</h2>
+      <p>
+        If we change this policy in a way that materially affects waitlist subscribers,
+        we will email you before the change takes effect. Minor edits will be posted
+        here with an updated "Last updated" date.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        Questions, deletion requests, or data-protection concerns:
+        <a href="mailto:hello@heysummon.ai">hello@heysummon.ai</a>.
+      </p>
+    </main>
+    <footer>
+      <a href="/">Home</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="mailto:hello@heysummon.ai">Contact</a>
+      <div style="margin-top:0.75rem;">&copy; 2026 HeySummon.</div>
+    </footer>
+  </body>
+</html>

--- a/landingspage/public/terms.html
+++ b/landingspage/public/terms.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Terms of Service — HeySummon</title>
+    <meta name="description" content="HeySummon terms of service for the marketing site, the launch waitlist, and the open-source product." />
+    <meta name="robots" content="index,follow" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Joti+One&display=swap" rel="stylesheet">
+    <style>
+      :root {
+        --bg-deep: #0f1410;
+        --bg-card: #1e2420;
+        --text-heading: #e8e4df;
+        --text-body: #9a958e;
+        --text-muted: #6b6660;
+        --primary: #ff826d;
+        --border: rgba(255, 255, 255, 0.1);
+      }
+      * { box-sizing: border-box; }
+      html { scroll-behavior: smooth; }
+      body {
+        margin: 0;
+        background: var(--bg-deep);
+        color: var(--text-body);
+        font-family: 'DM Sans', system-ui, sans-serif;
+        line-height: 1.7;
+        -webkit-font-smoothing: antialiased;
+      }
+      a { color: var(--primary); text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      header {
+        border-bottom: 1px solid var(--border);
+        padding: 1.5rem 2rem;
+      }
+      header .inner {
+        max-width: 64rem;
+        margin: 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+      header img { height: 2rem; width: auto; }
+      header nav a {
+        color: var(--text-body);
+        margin-left: 1.25rem;
+        font-size: 0.875rem;
+      }
+      header nav a:hover { color: var(--text-heading); text-decoration: none; }
+      main {
+        max-width: 48rem;
+        margin: 0 auto;
+        padding: 3rem 2rem 5rem;
+      }
+      h1, h2, h3 { color: var(--text-heading); line-height: 1.25; }
+      h1 { font-size: 2.25rem; margin: 0 0 0.5rem; }
+      h2 { font-size: 1.375rem; margin: 2.5rem 0 0.75rem; }
+      h3 { font-size: 1.05rem; margin: 1.75rem 0 0.5rem; }
+      p, ul { margin: 0 0 1rem; }
+      ul { padding-left: 1.25rem; }
+      li { margin-bottom: 0.35rem; }
+      .meta { color: var(--text-muted); font-size: 0.875rem; margin-bottom: 2rem; }
+      footer {
+        border-top: 1px solid var(--border);
+        padding: 2rem;
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 0.875rem;
+      }
+      footer a { color: var(--text-body); margin: 0 0.5rem; }
+      footer a:hover { color: var(--text-heading); text-decoration: none; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="inner">
+        <a href="/"><img src="/logo.png" alt="HeySummon" /></a>
+        <nav>
+          <a href="/">Home</a>
+          <a href="https://docs.heysummon.ai">Docs</a>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <h1>Terms of Service</h1>
+      <p class="meta">Last updated: 1 May 2026</p>
+
+      <p>
+        These terms govern your use of the HeySummon marketing website
+        (<a href="https://heysummon.ai">heysummon.ai</a>), the launch waitlist
+        (<a href="https://cloud.heysummon.ai">cloud.heysummon.ai</a>), and the
+        open-source HeySummon software. By using any of them you agree to these
+        terms. If you do not agree, do not use the site.
+      </p>
+
+      <h2>1. Who we are</h2>
+      <p>
+        HeySummon is operated by Thomas Ansems (Netherlands). For any questions
+        about these terms, contact
+        <a href="mailto:hello@heysummon.ai">hello@heysummon.ai</a>.
+      </p>
+
+      <h2>2. The marketing site</h2>
+      <p>
+        The marketing site is provided as-is for informational purposes. Content,
+        screenshots, and product claims describe HeySummon as it exists or is
+        planned at the time of writing and may change without notice.
+      </p>
+
+      <h2>3. The launch waitlist</h2>
+      <p>
+        Joining the waitlist means we will email you when the hosted product opens
+        and may send a small number of launch updates. Joining the waitlist does
+        not guarantee access, a free tier, or any specific pricing. You can leave
+        the waitlist at any time using the unsubscribe link in any email or by
+        contacting <a href="mailto:hello@heysummon.ai">hello@heysummon.ai</a>.
+        See our <a href="/privacy.html">Privacy Policy</a> for what we collect.
+      </p>
+
+      <h2>4. Open-source software</h2>
+      <p>
+        HeySummon is distributed under the
+        <a href="https://github.com/thomasansems/heysummon/blob/main/LICENSE.md" target="_blank" rel="noopener">Sustainable Use License</a>.
+        Your rights to use, copy, modify, and redistribute the software are
+        governed by that license, not by these Terms. Where the license and these
+        Terms conflict in respect of the software, the license controls.
+      </p>
+      <p>
+        The software is provided "as is", without warranty of any kind. To the
+        maximum extent permitted by law, the authors and copyright holders are
+        not liable for any claim, damages, or other liability arising from your
+        use of the software.
+      </p>
+
+      <h2>5. Acceptable use of the marketing site</h2>
+      <p>You agree not to:</p>
+      <ul>
+        <li>Use the site to violate any law or third-party right.</li>
+        <li>
+          Submit obviously fake, abusive, or automated waitlist sign-ups, or
+          attempt to enumerate, scrape, or overload our forms.
+        </li>
+        <li>
+          Probe, scan, or test the vulnerability of the site without prior written
+          permission. If you believe you have found a security issue, please email
+          <a href="mailto:hello@heysummon.ai">hello@heysummon.ai</a>.
+        </li>
+      </ul>
+      <p>
+        We may remove waitlist entries or block access if these terms are
+        violated.
+      </p>
+
+      <h2>6. Intellectual property</h2>
+      <p>
+        The HeySummon name, logo, and brand assets are owned by us. You may not
+        use them in a way that suggests endorsement, affiliation, or sponsorship
+        without our written permission. The site's content (text, images,
+        graphics) is, unless otherwise noted, owned by us or our licensors.
+      </p>
+
+      <h2>7. Third-party links</h2>
+      <p>
+        The site may link to third-party services (GitHub, Discord, documentation
+        host, etc.). We are not responsible for those services or their content.
+      </p>
+
+      <h2>8. Disclaimer and liability</h2>
+      <p>
+        The marketing site and waitlist are provided as-is, without warranties of
+        any kind, express or implied. To the extent permitted by law, we are not
+        liable for any indirect, incidental, special, consequential, or punitive
+        damages arising from your use of the site or waitlist. Nothing in these
+        terms limits liability that cannot be limited under applicable law
+        (including for fraud or gross negligence).
+      </p>
+
+      <h2>9. Changes</h2>
+      <p>
+        We may update these terms. Material changes affecting waitlist subscribers
+        will be communicated by email. Minor edits will be posted here with an
+        updated "Last updated" date. Continued use after changes are posted means
+        you accept the updated terms.
+      </p>
+
+      <h2>10. Governing law</h2>
+      <p>
+        These terms are governed by the laws of the Netherlands. Disputes will be
+        brought before the competent courts of Amsterdam, the Netherlands, except
+        where mandatory consumer-protection law gives you the right to a different
+        forum.
+      </p>
+
+      <h2>11. Contact</h2>
+      <p>
+        Questions about these terms:
+        <a href="mailto:hello@heysummon.ai">hello@heysummon.ai</a>.
+      </p>
+    </main>
+    <footer>
+      <a href="/">Home</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="mailto:hello@heysummon.ai">Contact</a>
+      <div style="margin-top:0.75rem;">&copy; 2026 HeySummon.</div>
+    </footer>
+  </body>
+</html>

--- a/landingspage/src/components/Footer.tsx
+++ b/landingspage/src/components/Footer.tsx
@@ -7,10 +7,13 @@ export function Footer() {
         <div className="flex items-center">
           <img src="/logo.png" alt="HeySummon Logo" className="h-8 w-auto grayscale hover:grayscale-0 transition-all opacity-80 hover:opacity-100" />
         </div>
-        <div className="flex gap-6 text-sm text-text-body">
+        <div className="flex flex-wrap justify-center gap-x-6 gap-y-3 text-sm text-text-body">
           <a href="https://docs.heysummon.ai" target="_blank" rel="noopener noreferrer" onClick={() => trackDocsClick('footer')} className="hover:text-text-heading transition-colors">Documentation</a>
           <a href="https://github.com/thomasansems/heysummon" target="_blank" rel="noopener noreferrer" onClick={() => trackGithubClick('footer')} className="hover:text-text-heading transition-colors">GitHub</a>
           <a href="https://cloud.heysummon.ai" target="_blank" rel="noopener noreferrer" onClick={() => trackWaitlistClick('footer')} className="hover:text-text-heading transition-colors">Cloud</a>
+          <a href="/privacy.html" className="hover:text-text-heading transition-colors">Privacy</a>
+          <a href="/terms.html" className="hover:text-text-heading transition-colors">Terms</a>
+          <a href="mailto:hello@heysummon.ai" className="hover:text-text-heading transition-colors">Contact</a>
         </div>
         <div className="text-sm text-text-muted">
           &copy; 2026 HeySummon. Sustainable Use License.


### PR DESCRIPTION
## Summary

Closes [HEY-514](https://paperclip.ing) — `[B3]` from the QA report (legal/launch blocker).

The waitlist captures emails on cloud.heysummon.ai, but the landing page had no Privacy / Terms / Contact links. That's a GDPR/CCPA exposure and most ad networks (Google Ads, LinkedIn) reject sites without a public privacy policy.

- `landingspage/src/components/Footer.tsx` — add **Privacy**, **Terms**, **Contact** (`mailto:hello@heysummon.ai`) links. Link row switched to `flex flex-wrap` with column/row gaps so it doesn't overflow on mobile.
- `landingspage/public/privacy.html` — boilerplate Privacy Policy that **explicitly** covers waitlist email collection, retention (24 months / unsubscribe), and how to request deletion (email `hello@heysummon.ai`). Calls out that self-hosted HeySummon never sends operational data to us, that we use cookieless Umami analytics, and that we don't run third-party trackers on the marketing site.
- `landingspage/public/terms.html` — standard Terms of Service for the marketing site, the waitlist, and the open-source software (which defers software rights to the [Sustainable Use License](https://github.com/thomasansems/heysummon/blob/main/LICENSE.md)).

Both pages are styled inline to match the dark landing-page theme without dragging in the React bundle, and they cross-link to each other and `mailto:hello@heysummon.ai`.

## Acceptance criteria (from the issue)

- [x] Footer has visible Privacy, Terms, Contact (`hello@heysummon.ai`) links on desktop and mobile.
- [x] Privacy and Terms render at their final URLs (`/privacy.html`, `/terms.html`) — Vite serves `public/` as-is, Vercel will return 200.
- [x] Privacy explicitly mentions waitlist email collection, retention, and deletion-request channel.
- [x] Mobile footer doesn't overflow — link row now wraps via `flex-wrap`.

## Test plan

- [ ] `pnpm --filter heysummon-landing-page dev` and confirm the three new footer links render on desktop and mobile fold; resize down to 375px and confirm no overflow.
- [ ] Click each link: Privacy → `/privacy.html` renders; Terms → `/terms.html` renders; Contact → opens mail client to `hello@heysummon.ai`.
- [ ] Privacy and Terms render correctly with the dark theme and Joti One / DM Sans fonts.
- [ ] Lighthouse a11y on `/privacy.html` and `/terms.html` (semantic headings, link contrast).
- [ ] Vercel preview deploy: confirm both URLs return 200.

## Follow-up

Boilerplate text is acceptable for launch per the issue. A thorough legal review can land later — leave a comment tagging `@legal-specialist` on the PR if a content review is wanted before merge; do not block the footer wiring on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>