### PR TITLE
feat(landingspage): GitHub stars social proof above the fold (HEY-516)

### DIFF
--- a/landingspage/src/components/GitHubStars.tsx
+++ b/landingspage/src/components/GitHubStars.tsx
@@ -1,0 +1,39 @@
+import { Star } from 'lucide-react';
+import { trackGithubClick } from '../lib/analytics';
+
+const GITHUB_REPO_URL = 'https://github.com/thomasansems/heysummon';
+const FALLBACK_LABEL = 'Star on GitHub';
+
+function humanizeCount(value: number): string {
+  if (value < 1000) return value.toString();
+  const thousands = value / 1000;
+  return `${thousands.toFixed(thousands < 10 ? 1 : 0).replace(/\.0$/, '')}k`;
+}
+
+interface GitHubStarsProps {
+  location: string;
+  className?: string;
+}
+
+export function GitHubStars({ location, className }: GitHubStarsProps) {
+  const stars = typeof __GITHUB_STARS__ === 'number' ? __GITHUB_STARS__ : null;
+  const label = stars === null ? FALLBACK_LABEL : `${humanizeCount(stars)} on GitHub`;
+
+  return (
+    <a
+      href={GITHUB_REPO_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() => trackGithubClick(location)}
+      aria-label={
+        stars === null
+          ? 'Star HeySummon on GitHub'
+          : `HeySummon has ${stars.toLocaleString('en-US')} stars on GitHub`
+      }
+      className={`inline-flex items-center gap-2 px-4 py-1.5 rounded-full font-mono text-sm text-text-body bg-white/5 border border-white/10 backdrop-blur-md hover:bg-white/10 transition-colors ${className ?? ''}`.trim()}
+    >
+      <Star className="w-4 h-4 fill-current text-yellow-300" aria-hidden="true" />
+      <span>{label}</span>
+    </a>
+  );
+}

--- a/landingspage/src/components/Hero.tsx
+++ b/landingspage/src/components/Hero.tsx
@@ -44,13 +44,16 @@ export function Hero() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="inline-flex items-center gap-3 px-5 py-2 rounded-full font-mono text-sm text-text-body bg-white/5 border border-white/10 backdrop-blur-md mb-10"
+          className="flex flex-wrap items-center justify-center gap-3 mb-10"
         >
-          <span>Open Source</span>
-          <span className="w-1 h-1 rounded-full bg-white/50"></span>
-          <span>Self-Hosted</span>
-          <span className="w-1 h-1 rounded-full bg-white/50"></span>
-          <span>Platform Agnostic</span>
+          <span className="inline-flex items-center gap-3 px-5 py-2 rounded-full font-mono text-sm text-text-body bg-white/5 border border-white/10 backdrop-blur-md">
+            <span>Open Source</span>
+            <span className="w-1 h-1 rounded-full bg-white/50"></span>
+            <span>Self-Hosted</span>
+            <span className="w-1 h-1 rounded-full bg-white/50"></span>
+            <span>Platform Agnostic</span>
+          </span>
+          <GitHubStars location="hero" />
         </motion.div>
 
         <h1 className="font-serif text-3xl sm:text-5xl md:text-7xl leading-tight tracking-tight mb-6">

--- a/landingspage/src/vite-env.d.ts
+++ b/landingspage/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __GITHUB_STARS__: number | null;

--- a/landingspage/vite.config.ts
+++ b/landingspage/vite.config.ts
@@ -3,14 +3,40 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 import {defineConfig, loadEnv} from 'vite';
 
-export default defineConfig(({mode}) => {
+async function fetchGithubStars(repo: string): Promise<number | null> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'heysummon-landingpage-build',
+    };
+    if (process.env.GITHUB_TOKEN) {
+      headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
+    const res = await fetch(`https://api.github.com/repos/${repo}`, {
+      headers,
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    if (!res.ok) return null;
+    const data = (await res.json()) as { stargazers_count?: number };
+    return typeof data.stargazers_count === 'number' ? data.stargazers_count : null;
+  } catch {
+    return null;
+  }
+}
+
+export default defineConfig(async ({mode}) => {
   const env = loadEnv(mode, '.', '');
+  const githubStars = await fetchGithubStars('thomasansems/heysummon');
   return {
     plugins: [react(), tailwindcss()],
     define: {
       'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
       'process.env.VITE_UMAMI_WEBSITE_ID': JSON.stringify(env.VITE_UMAMI_WEBSITE_ID),
       'process.env.VITE_UMAMI_URL': JSON.stringify(env.VITE_UMAMI_URL),
+      __GITHUB_STARS__: JSON.stringify(githubStars),
     },
     resolve: {
       alias: {
@@ -19,7 +45,7 @@ export default defineConfig(({mode}) => {
     },
     server: {
       // HMR is disabled in AI Studio via DISABLE_HMR env var.
-      // Do not modifyâfile watching is disabled to prevent flickering during agent edits.
+      // Do not modifyâfile watching is disabled to prevent flickering during agent edits.
       hmr: process.env.DISABLE_HMR !== 'true',
     },
   };


### PR DESCRIPTION
## Summary

Adds a single, above-the-fold credibility signal to the hero on heysummon.ai: a `★ N on GitHub` badge linking to the public repo, addressing the QA report's H2 finding (HEY-44 / HEY-516) that the hero had no social proof.

- Star count fetched **server-side at build time** from the GitHub REST API and inlined into the bundle via a Vite `define` constant — no runtime API calls, no extra request, no rate-limit risk for visitors.
- Graceful fallback to a `Star on GitHub` CTA label when the API is unreachable (5s timeout, optional `GITHUB_TOKEN` for authenticated builds in CI). The page never breaks if upstream is down.
- Counts ≥ 1k render humanized (e.g. `1.2k`).
- Visible above the fold on **desktop and mobile** — sits in a `flex-wrap` row next to the existing `Open Source / Self-Hosted / Platform Agnostic` pill, wraps to a new line on narrow viewports.
- Click is tracked via the existing `trackGithubClick('hero')` analytics helper.
- Accessible: descriptive `aria-label` reflecting the live count, decorative star icon hidden from AT.

## Files

- `landingspage/vite.config.ts` — build-time GitHub stars fetch + define constant
- `landingspage/src/vite-env.d.ts` — `__GITHUB_STARS__` ambient declaration
- `landingspage/src/components/GitHubStars.tsx` — new component
- `landingspage/src/components/Hero.tsx` — slot the badge next to the existing pill

## Acceptance criteria

- [x] One social-proof element visible in the hero on desktop **and** mobile
- [x] Server-side fetch is cached (build-time inlining) and has a graceful fallback
- [x] Numbers render with a humanized format (e.g. `1.2k`)

## Test plan

- [ ] `pnpm --prefix landingspage lint` passes
- [ ] `pnpm --prefix landingspage build` succeeds and bundle contains `on GitHub`
- [ ] Visual check on desktop and mobile viewports — badge visible above the fold, no horizontal overflow on narrow widths
- [ ] Click on the badge opens `https://github.com/thomasansems/heysummon` in a new tab and fires `github_click` analytics event
- [ ] Build with `unset GITHUB_TOKEN` and a network-blocked environment to verify the fallback label renders

## References

- Issue: HEY-516
- Parent: HEY-44
- QA report: `.scans/qa-hey44/QA-REPORT.md` (H2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)